### PR TITLE
docs(benchmarks/robocasa365): document split tracks and trial counts

### DIFF
--- a/benchmarks/robocasa365/README.md
+++ b/benchmarks/robocasa365/README.md
@@ -50,6 +50,18 @@ WebSocket port 8848 by default (`--port` to change). Keep it running.
 
 ## 3. Run the Evaluation
 
+**Split and trials.**
+
+- `pretrain` (default) — the leaderboard / multi-task protocol: the 50 target tasks
+  evaluated in training-distribution kitchens (paper §4.1). All §4 numbers use this.
+- `target` — the foundation track: evaluate in the 10 held-out kitchens after
+  finetuning on target demos (§4.2). Pass it explicitly.
+- In `multi_eval.sh target`, that `target` is the task-list token, not the split.
+- The commands below run `num_trials: 5` per task (smoke scale, from
+  `policy_config.yml`); benchmark numbers use 50 rollouts/task
+  ([protocol](https://robocasa.ai/docs/build/html/benchmarking/benchmarking_overview.html)) —
+  copy `policy_config.yml`, set `num_trials: 50`, and point `ROBOCASA365_POLICY_CONFIG` at it.
+
 Single task (args: task, split, port, host):
 
 ```bash
@@ -78,7 +90,7 @@ bash benchmarks/robocasa365/run_eval.sh \
 
 - The server's ping must advertise representation `robocasa365` — the client hard-fails otherwise. The released checkpoint matches; your own must be trained on the robocasa365 conversion.
 - Rollout horizons come from robocasa's official task registry at runtime; leave `max_steps_override: null` in `policy_config.yml` for benchmark runs.
-- Client defaults live in `benchmarks/robocasa365/policy_config.yml` (5 trials/task, `pretrain` split). Splits: `pretrain` = training-distribution kitchens (layouts/styles 11-60), `target` = the official 10 held-out evaluation kitchens, `all` = everything; pass the split as arg 2 / `--split` / `SPLIT=` to switch. CLI flags and `ROBOCASA365_PORT` / `ROBOCASA365_POLICY_HOST` override; `ROBOCASA365_POLICY_CONFIG` points at a custom file.
+- Client defaults live in `benchmarks/robocasa365/policy_config.yml` (5 trials/task — smoke scale, see *Split and trials* above — and `pretrain` split). Splits: `pretrain` = training-distribution kitchens (layouts/styles 11-60), the leaderboard/multi-task protocol; `target` = the 10 held-out kitchens of the foundation-model (finetune) track; `all` = everything; pass the split as arg 2 / `--split` / `SPLIT=` to switch. CLI flags and `ROBOCASA365_PORT` / `ROBOCASA365_POLICY_HOST` override; `ROBOCASA365_POLICY_CONFIG` points at a custom file.
 - `multi_eval.sh` tasks: literal names, `target`/`all` (expands `target_tasks.txt`), or a file; per-task success rates aggregate into `<out>/summary_<split>.csv`.
 - `run_eval.sh` requires an explicit checkpoint filename (substitute your actual `checkpoint_step_*.safetensors`) and writes `server.log` / `client.log` / `tasks/summary_<split>.csv` under `outputs/robocasa365/<timestamp>` (override with `OUTPUT_DIR`); `scripts/deploy.sh` alone may omit `--ckpt-name` (picks the latest).
 


### PR DESCRIPTION
## What

Documents the evaluation protocol choices that the folder's defaults already encode but never explain:

- **A "Split and trials" primer** at the top of §3 Run the Evaluation:
  - `pretrain` (the default) = the leaderboard / multi-task protocol — the 50 target tasks evaluated in training-distribution kitchens (RoboCasa365 paper §4.1, Table 1). All numbers in §4 use this.
  - `target` = the foundation track — eval in the 10 held-out kitchens after finetuning on target demos (§4.2, Table 2); must be passed explicitly.
  - Disambiguates the word `target`, which does double duty as a *split* value and as the *task-list token* in `multi_eval.sh target` — this exact collision has already confused readers.
  - States that the example commands run at smoke scale (`num_trials: 5` from `policy_config.yml`) while benchmark numbers use **50 rollouts/task** per the [official protocol](https://robocasa.ai/docs/build/html/benchmarking/benchmarking_overview.html), with the concrete override path (`ROBOCASA365_POLICY_CONFIG`).
- **Reword one Notes bullet** that called the target kitchens "the official 10 held-out evaluation kitchens" — "official" there invites the exact misreading (that official evaluation = `target` split) the defaults were fixed to prevent.

## Why

The split defaults were correctly set to `pretrain` throughout, but nothing in the README said why, or which track the leaderboard uses. Verified against the RoboCasa365 paper (§4.1 "We evaluate in the pretraining kitchen scenes for each task" vs §4.2 "in the target kitchens") and cross-checked numerically: the leaderboard's internal baseline rows equal paper Table 1 (multi-task, pretraining scenes) cell-for-cell (π0.5 39.6/7.1/1.2, DP 15.7/0.2/1.3).

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
