### PR TITLE
Make RoboTwin evaluation reproducible from the docs alone

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,23 @@ make check     # compile check
 make all       # lint and compile check
 ~~~
 
+## Running GPU tests
+
+`make test` runs the CPU suite (`-m "not gpu"`). Tests that need real weights are
+marked `gpu` and resolve their assets through `tests/_assets.py`: each asset is
+looked up first in an `OPENWAM_<ASSET>` environment variable, then at the
+directory the downloader in `scripts/download_assets/` writes to by default. So
+after downloading with the repo scripts nothing needs to be set:
+
+~~~bash
+python scripts/download_assets/download_video_backbone.py --name Wan2.2-TI2V-5B --yes
+pytest -m gpu tests/test_video_backbone_consistency.py
+~~~
+
+To point at weights stored elsewhere, export the matching variable, e.g.
+`OPENWAM_WAN22_TI2V_5B=/data/Wan2.2-TI2V-5B`. The full list of names and default
+locations is in `tests/_assets.py`.
+
 ## Before submitting a PR
 
 1. Run make all and resolve any failures.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Then install OpenWAM:
 pip install -e .
 ```
 
+> `deepspeed` ships as a source distribution and is compiled during `pip install`, so a C compiler (`gcc`) must be on the PATH.
+
 <details>
 <summary><b>Cosmos-Predict2.5 Extras (Optional)</b> — needed only for experiments with the <code>cosmos_predict25_2b</code> video backbone</summary>
 
@@ -137,7 +139,7 @@ The script installs the upstream cosmos packages into the active environment and
 
 ## Assets Preparation
 
-The downloaders are interactive. Component downloaders store assets under
+The downloaders are interactive by default; every menu step also has a flag (`--name`, `--source`, `--root`, `--yes`, see `--help`) so they can run unattended, and the default storage location is resolved relative to the repository regardless of the working directory. Component downloaders store assets under
 `assets/` and update the matching YAML path; the released-checkpoint downloader
 keeps each checkpoint's self-contained config unchanged.
 

--- a/benchmarks/robotwin/README.md
+++ b/benchmarks/robotwin/README.md
@@ -76,10 +76,10 @@ bash benchmarks/robotwin/multi_eval.sh -m demo_clean -n run1 \
   - `prewarmed CUDA/Curobo before SAPIEN import` — cuRobo must initialise CUDA before SAPIEN's Vulkan context exists, otherwise the first plan segfaults.
   - `patched warp.torch compatibility namespace` — cuRobo v0.7.8 still calls `warp.torch.*`, which warp ≥ 1.x no longer ships; the wrapper aliases the new top-level functions.
   - `SAPIEN EGL ICD: …` (from `single_eval.sh`) — SAPIEN's EGL probe crashes on images without `/usr/share/glvnd/egl_vendor.d`; the script points it at SAPIEN's bundled ICD instead.
-  - `WARNING: RoboTwin at … differs from the verified commit` — see the table above; check out the verified commit before debugging anything else.
+  - `RoboTwin commit=… eval_policy.py sha256=…` — provenance of the RoboTwin code actually loaded; a `WARNING` follows if the commit differs from the verified one or files under `script/ envs/ task_config/ policy/` are locally modified. Check out the verified commit before debugging anything else.
 - If cuRobo planning itself fails, set `ROBOTWIN_ENABLE_PLANNER_FALLBACK=1` to plan with `mplib_RRT` instead (slower, results not comparable to the tables below).
 - Read-only checkout? Set `ROBOTWIN_RUNTIME_ROOT` to a writable dir. Per-task step limits: `benchmarks/robotwin/step_limits.yml` (all commented out by default; read once at startup).
-- Results: RoboTwin's native `eval_result/` inside the checkout (or runtime root); `multi_eval.sh` also tees per-task logs under `<ckpt_dir>/robotwin_eval_logs/…`, writes the run parameters to `run.env` there, and prints each task's `Success rate`.
+- Results: RoboTwin's native `eval_result/` inside the checkout (or runtime root); `multi_eval.sh` also tees per-task logs under `<ckpt_dir>/robotwin_eval_logs/…`, records the run there (`run.env` — shell-quoted, `source`-able — plus verbatim copies of the `policy_config.yml` and `step_limits.yml` used), and prints each task's `Success rate`.
 
 </details>
 

--- a/benchmarks/robotwin/README.md
+++ b/benchmarks/robotwin/README.md
@@ -15,8 +15,20 @@ git clone https://github.com/RoboTwin-Platform/RoboTwin.git /path/to/RoboTwin
 /path/to/miniconda3/envs/robotwin/bin/pip install websockets pyyaml   # client deps OpenWAM needs
 ```
 
-- `ROBOTWIN_PATH` → the checkout; `ROBOTWIN_PYTHON` → `/path/to/miniconda3/envs/robotwin/bin/python`. Every eval command needs both.
-- Headless node? Prefix commands with `xvfb-run -a` (SAPIEN needs a display).
+- `ROBOTWIN_PATH` → the checkout; `ROBOTWIN_PYTHON` → `/path/to/miniconda3/envs/robotwin/bin/python`. Every eval command needs both (`single_eval.sh` refuses to start without them).
+- Headless nodes normally work as-is: SAPIEN renders offscreen through its bundled Vulkan loader, no X server needed. Only if you hit a display/EGL error at SAPIEN import, prefix the command with `xvfb-run -a`.
+
+**Verified versions.** The adapter (`eval_policy_wrapper.py`) loads RoboTwin's `script/eval_policy.py` by path and patches it, so it is tied to the upstream layout. The combination below is what the released checkpoints were evaluated with; other versions may work but are unverified (the wrapper prints a warning when the RoboTwin commit differs, `ROBOTWIN_SKIP_VERSION_CHECK=1` silences it).
+
+| Component | Version |
+|---|---|
+| RoboTwin | commit `0aeea2d669c0f8516f4d5785f0aa33ba812c14b4` (2026-04-19) |
+| Python (RoboTwin env) | 3.10 |
+| SAPIEN | 3.0.0b1 |
+| cuRobo | v0.7.8, built into `<RoboTwin>/envs/curobo` by RoboTwin's `script/_install.sh` |
+| warp-lang | 1.13.0 |
+| mplib | 0.2.1 |
+| torch (RoboTwin env) | 2.4.1 (the policy server uses OpenWAM's own env) |
 
 ## 2. Start the Policy Server
 
@@ -60,15 +72,22 @@ bash benchmarks/robotwin/multi_eval.sh -m demo_clean -n run1 \
 - Start the server first; the client health-checks it for up to 300 s, then aborts. Remote server: pass `[host]`/`[port]` (single) or `--host`/`--port` (multi); defaults `127.0.0.1:8848`.
 - `task_config` ∈ {`demo_clean`, `demo_randomized`}; `ckpt_setting` is only a label in RoboTwin's result filenames; `-d` is used for log placement — weights never load client-side.
 - `ROBOTWIN_TEST_NUM=5` caps episodes per task for a quick smoke run (default 100/task; the full `all` run takes many GPU-hours per mode).
-- Startup CUDA/cuRobo prewarm chatter from `eval_policy_wrapper.py` is expected; don't call RoboTwin's `eval_policy.py` directly. If cuRobo planning fails, set `ROBOTWIN_ENABLE_PLANNER_FALLBACK=1`.
+- Don't call RoboTwin's `eval_policy.py` directly — go through `eval_policy_wrapper.py`. Its startup messages are expected; each one works around a known crash in the verified stack:
+  - `prewarmed CUDA/Curobo before SAPIEN import` — cuRobo must initialise CUDA before SAPIEN's Vulkan context exists, otherwise the first plan segfaults.
+  - `patched warp.torch compatibility namespace` — cuRobo v0.7.8 still calls `warp.torch.*`, which warp ≥ 1.x no longer ships; the wrapper aliases the new top-level functions.
+  - `SAPIEN EGL ICD: …` (from `single_eval.sh`) — SAPIEN's EGL probe crashes on images without `/usr/share/glvnd/egl_vendor.d`; the script points it at SAPIEN's bundled ICD instead.
+  - `WARNING: RoboTwin at … differs from the verified commit` — see the table above; check out the verified commit before debugging anything else.
+- If cuRobo planning itself fails, set `ROBOTWIN_ENABLE_PLANNER_FALLBACK=1` to plan with `mplib_RRT` instead (slower, results not comparable to the tables below).
 - Read-only checkout? Set `ROBOTWIN_RUNTIME_ROOT` to a writable dir. Per-task step limits: `benchmarks/robotwin/step_limits.yml` (all commented out by default; read once at startup).
-- Results: RoboTwin's native `eval_result/` inside the checkout (or runtime root); `multi_eval.sh` also tees per-task logs under `<ckpt_dir>/robotwin_eval_logs/…` and prints each task's `Success rate`.
+- Results: RoboTwin's native `eval_result/` inside the checkout (or runtime root); `multi_eval.sh` also tees per-task logs under `<ckpt_dir>/robotwin_eval_logs/…`, writes the run parameters to `run.env` there, and prints each task's `Success rate`.
 
 </details>
 
 ## 4. Results
 
 Scores from the OpenWAM paper. **Bold** = best, <u>underline</u> = second best; Type distinguishes WAM vs VLA.
+
+Evaluation protocol for the OpenWAM-α rows (reproduce with the commands in §3): released checkpoint served with `scripts/deploy.sh` defaults from `configs/deploy.yaml` — `denoise_steps: 10`, `denoise_mode: sync`, DiT velocity cache **on** (`cosine_threshold: 0.99`, `max_skips: 3`), `torch.compile` on — 100 episodes per task at seed 0, RoboTwin's upstream per-task step limits (`step_limits.yml` empty), and the versions in §1. Changing any of these (in particular disabling the DiT cache) changes the numbers.
 
 **RoboTwin2.0-Clean2Random** (fine-tune on clean only; OOD probe):
 

--- a/benchmarks/robotwin/eval_policy_wrapper.py
+++ b/benchmarks/robotwin/eval_policy_wrapper.py
@@ -5,10 +5,49 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import subprocess
 import sys
 import tempfile
 import traceback
 import types
+
+# RoboTwin commit this adapter was last verified against (see the "Verified
+# versions" table in README.md). The adapter loads RoboTwin's
+# ``script/eval_policy.py`` by path and monkeypatches it, so an upstream change
+# can break it silently; a mismatch here is the first thing to suspect.
+VERIFIED_ROBOTWIN_COMMIT = "0aeea2d669c0f8516f4d5785f0aa33ba812c14b4"
+
+
+def _warn_on_unverified_robotwin(robotwin_path: str) -> None:
+    """Print a warning when ``robotwin_path`` is not at the verified commit.
+
+    Non-fatal: other commits usually work, and ``ROBOTWIN_SKIP_VERSION_CHECK=1``
+    silences the check entirely (e.g. for a non-git RoboTwin copy).
+    """
+    if os.environ.get("ROBOTWIN_SKIP_VERSION_CHECK", "") == "1":
+        return
+    try:
+        head = subprocess.run(
+            ["git", "-C", robotwin_path, "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        head = ""
+    if not head:
+        print(
+            "[eval_policy_wrapper] WARNING: could not read the RoboTwin git commit "
+            f"(not a git checkout?); verified commit is {VERIFIED_ROBOTWIN_COMMIT[:12]}"
+        )
+        return
+    if head != VERIFIED_ROBOTWIN_COMMIT:
+        print(
+            f"[eval_policy_wrapper] WARNING: RoboTwin at {head[:12]} differs from the verified "
+            f"commit {VERIFIED_ROBOTWIN_COMMIT[:12]}; if eval breaks, check out the verified commit "
+            "first (set ROBOTWIN_SKIP_VERSION_CHECK=1 to silence)."
+        )
 
 
 def _load_robotwin_eval_module(robotwin_path: str):
@@ -303,6 +342,7 @@ def bootstrap_robotwin_module(*, install_trace_hooks: bool = True):
     if not robotwin_path:
         raise SystemExit("ROBOTWIN_PATH must be set")
 
+    _warn_on_unverified_robotwin(robotwin_path)
     runtime_root = _prepare_runtime_root(robotwin_path)
     os.chdir(runtime_root)
     if robotwin_path not in sys.path:

--- a/benchmarks/robotwin/eval_policy_wrapper.py
+++ b/benchmarks/robotwin/eval_policy_wrapper.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import os
 import subprocess
@@ -11,42 +12,61 @@ import tempfile
 import traceback
 import types
 
-# RoboTwin commit this adapter was last verified against (see the "Verified
-# versions" table in README.md). The adapter loads RoboTwin's
-# ``script/eval_policy.py`` by path and monkeypatches it, so an upstream change
-# can break it silently; a mismatch here is the first thing to suspect.
+# RoboTwin commit this adapter was verified against (README "Verified versions").
 VERIFIED_ROBOTWIN_COMMIT = "0aeea2d669c0f8516f4d5785f0aa33ba812c14b4"
+# RoboTwin paths the adapter depends on; local edits there invalidate the check.
+_ROBOTWIN_WATCHED_PATHS = ("script", "envs", "task_config", "policy")
+
+
+def _robotwin_git(robotwin_path: str, *args: str) -> str:
+    try:
+        return subprocess.run(
+            ["git", "-C", robotwin_path, *args], capture_output=True, text=True, timeout=10, check=False
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def _file_sha256(path: str) -> str:
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
 
 
 def _warn_on_unverified_robotwin(robotwin_path: str) -> None:
-    """Print a warning when ``robotwin_path`` is not at the verified commit.
+    """Log RoboTwin provenance; warn when it differs from the verified state.
 
-    Non-fatal: other commits usually work, and ``ROBOTWIN_SKIP_VERSION_CHECK=1``
-    silences the check entirely (e.g. for a non-git RoboTwin copy).
+    Non-fatal. Checks the HEAD commit and local modifications under the paths
+    the adapter loads from, and always prints the hash of the
+    ``script/eval_policy.py`` actually loaded. ``ROBOTWIN_SKIP_VERSION_CHECK=1``
+    disables the git checks (e.g. for a non-git RoboTwin copy).
     """
+    script_path = os.path.join(robotwin_path, "script", "eval_policy.py")
+    script_sha = _file_sha256(script_path)[:16] if os.path.isfile(script_path) else "missing"
     if os.environ.get("ROBOTWIN_SKIP_VERSION_CHECK", "") == "1":
+        print(f"[eval_policy_wrapper] RoboTwin version check skipped; eval_policy.py sha256={script_sha}")
         return
-    try:
-        head = subprocess.run(
-            ["git", "-C", robotwin_path, "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-            check=False,
-        ).stdout.strip()
-    except (OSError, subprocess.SubprocessError):
-        head = ""
+    head = _robotwin_git(robotwin_path, "rev-parse", "HEAD")
     if not head:
         print(
-            "[eval_policy_wrapper] WARNING: could not read the RoboTwin git commit "
-            f"(not a git checkout?); verified commit is {VERIFIED_ROBOTWIN_COMMIT[:12]}"
+            "[eval_policy_wrapper] WARNING: could not read the RoboTwin git commit (not a git checkout?); "
+            f"verified commit is {VERIFIED_ROBOTWIN_COMMIT[:12]}; eval_policy.py sha256={script_sha}"
         )
         return
+    modified = _robotwin_git(
+        robotwin_path, "status", "--porcelain", "--untracked-files=no", "--", *_ROBOTWIN_WATCHED_PATHS
+    ).splitlines()
+    print(f"[eval_policy_wrapper] RoboTwin commit={head[:12]} eval_policy.py sha256={script_sha}")
     if head != VERIFIED_ROBOTWIN_COMMIT:
         print(
-            f"[eval_policy_wrapper] WARNING: RoboTwin at {head[:12]} differs from the verified "
-            f"commit {VERIFIED_ROBOTWIN_COMMIT[:12]}; if eval breaks, check out the verified commit "
-            "first (set ROBOTWIN_SKIP_VERSION_CHECK=1 to silence)."
+            f"[eval_policy_wrapper] WARNING: RoboTwin at {head[:12]} differs from the verified commit "
+            f"{VERIFIED_ROBOTWIN_COMMIT[:12]}; if eval breaks, check out the verified commit first "
+            "(ROBOTWIN_SKIP_VERSION_CHECK=1 silences this)."
+        )
+    if modified:
+        shown = ", ".join(line.split(maxsplit=1)[-1] for line in modified[:5]) + (" …" if len(modified) > 5 else "")
+        print(
+            f"[eval_policy_wrapper] WARNING: RoboTwin has {len(modified)} locally modified file(s) under "
+            f"{'/'.join(_ROBOTWIN_WATCHED_PATHS)}: {shown}. Results may not match the verified stack."
         )
 
 

--- a/benchmarks/robotwin/multi_eval.sh
+++ b/benchmarks/robotwin/multi_eval.sh
@@ -158,27 +158,34 @@ timestamp="$(date +%Y%m%d_%H%M%S)"
 LOG_DIR="${ROBOTWIN_LOG_ROOT:-${CKPT_DIR}/robotwin_eval_logs/${POLICY_NAME}_${TASK_CONFIG}_${ckpt_label}_${timestamp}}"
 mkdir -p "${LOG_DIR}"
 
-# Freeze the client-side evaluation protocol next to the logs so a result
-# directory is self-describing. Server-side settings (denoise steps, DiT cache,
-# compile) come from configs/deploy.yaml unless overridden on scripts/deploy.sh;
-# they are printed in the deploy log, not visible from the client.
+# Record the client-side protocol next to the logs: run.env (shell-quoted, safe
+# to `source`) plus verbatim copies of the two config files it depends on.
+# Server-side settings are only visible in the deploy log.
 _git_head() { git -C "$1" rev-parse HEAD 2>/dev/null || echo "unknown"; }
-cat > "${LOG_DIR}/run.env" <<EOF
-timestamp=${timestamp}
-name=${POLICY_NAME}
-mode=${TASK_CONFIG}
-ckpt_dir=${CKPT_DIR}
-server=ws://${SERVER_HOST}:${PORT}
-gpu=${GPU_ID}
-seed=0
-test_num=${ROBOTWIN_TEST_NUM:-100}
-step_limit_overrides=$(grep -cvE '^\s*(#|$)' "${SCRIPT_DIR}/step_limits.yml" 2>/dev/null || true)  # entries in benchmarks/robotwin/step_limits.yml; 0 = RoboTwin upstream limits
-policy_config=${POLICY_CONFIG_PATH:-${SCRIPT_DIR}/policy_config.yml}
-robotwin_path=${ROBOTWIN_PATH:-}
-robotwin_commit=$(_git_head "${ROBOTWIN_PATH:-/nonexistent}")
-openwam_commit=$(_git_head "${SCRIPT_DIR}")
-tasks=${TASKS[*]}
-EOF
+_git_dirty() { git -C "$1" status --porcelain --untracked-files=no 2>/dev/null | wc -l; }
+_sha256() { if [[ -f "$1" ]]; then sha256sum "$1" | cut -d' ' -f1; else echo "missing"; fi; }
+_env() { printf '%s=%q\n' "$1" "$2"; }
+POLICY_CONFIG="${POLICY_CONFIG_PATH:-${SCRIPT_DIR}/policy_config.yml}"
+cp -f "${POLICY_CONFIG}" "${LOG_DIR}/policy_config.yml"
+cp -f "${SCRIPT_DIR}/step_limits.yml" "${LOG_DIR}/step_limits.yml" 2>/dev/null || true
+{
+    _env timestamp "${timestamp}"
+    _env name "${POLICY_NAME}"
+    _env mode "${TASK_CONFIG}"
+    _env ckpt_dir "${CKPT_DIR}"
+    _env server "ws://${SERVER_HOST}:${PORT}"
+    _env gpu "${GPU_ID}"
+    _env seed 0
+    _env test_num "${ROBOTWIN_TEST_NUM:-100}"
+    _env policy_config_sha256 "$(_sha256 "${POLICY_CONFIG}")"
+    _env step_limits_sha256 "$(_sha256 "${SCRIPT_DIR}/step_limits.yml")"
+    _env robotwin_path "${ROBOTWIN_PATH:-}"
+    _env robotwin_commit "$(_git_head "${ROBOTWIN_PATH:-/nonexistent}")"
+    _env robotwin_modified_files "$(_git_dirty "${ROBOTWIN_PATH:-/nonexistent}")"
+    _env openwam_commit "$(_git_head "${SCRIPT_DIR}")"
+    _env openwam_modified_files "$(_git_dirty "${SCRIPT_DIR}")"
+    _env tasks "${TASKS[*]}"
+} > "${LOG_DIR}/run.env"
 
 echo "[INFO] mode=${TASK_CONFIG}  name=${POLICY_NAME}"
 echo "[INFO] server=ws://${SERVER_HOST}:${PORT}  gpu=${GPU_ID}"
@@ -196,16 +203,18 @@ for task_name in "${TASKS[@]}"; do
     log_file="${LOG_DIR}/${task_name/\//_}_${TASK_CONFIG}.log"
     echo "[INFO] Starting task=${task_name}"
 
-    # Pipe to tee so the full output is saved; capture single_eval.sh's own exit code
-    # via PIPESTATUS[0] rather than grep's exit code.  grep is display-only and
-    # must not affect the success/failure decision.
+    # Pipe to tee so the full output is saved. Under `pipefail` a failing
+    # single_eval.sh fails the whole pipeline, so an `|| true` here would run
+    # and reset PIPESTATUS; disable errexit around the pipeline instead.
+    set +e
     ROBOTWIN_PORT="${PORT}" ROBOTWIN_POLICY_HOST="${SERVER_HOST}" \
     bash "${SCRIPT_DIR}/single_eval.sh" \
         "${task_name}" "${TASK_CONFIG}" "${POLICY_NAME}" \
         "${GPU_ID}" \
         "${PORT}" "${SERVER_HOST}" \
-        2>&1 | tee "${log_file}" || true
+        2>&1 | tee "${log_file}"
     eval_exit="${PIPESTATUS[0]}"
+    set -e
 
     grep --color=never "Success rate" "${log_file}" \
         | sed "s/^/[RESULT] ${task_name}: /" || true

--- a/benchmarks/robotwin/multi_eval.sh
+++ b/benchmarks/robotwin/multi_eval.sh
@@ -158,6 +158,28 @@ timestamp="$(date +%Y%m%d_%H%M%S)"
 LOG_DIR="${ROBOTWIN_LOG_ROOT:-${CKPT_DIR}/robotwin_eval_logs/${POLICY_NAME}_${TASK_CONFIG}_${ckpt_label}_${timestamp}}"
 mkdir -p "${LOG_DIR}"
 
+# Freeze the client-side evaluation protocol next to the logs so a result
+# directory is self-describing. Server-side settings (denoise steps, DiT cache,
+# compile) come from configs/deploy.yaml unless overridden on scripts/deploy.sh;
+# they are printed in the deploy log, not visible from the client.
+_git_head() { git -C "$1" rev-parse HEAD 2>/dev/null || echo "unknown"; }
+cat > "${LOG_DIR}/run.env" <<EOF
+timestamp=${timestamp}
+name=${POLICY_NAME}
+mode=${TASK_CONFIG}
+ckpt_dir=${CKPT_DIR}
+server=ws://${SERVER_HOST}:${PORT}
+gpu=${GPU_ID}
+seed=0
+test_num=${ROBOTWIN_TEST_NUM:-100}
+step_limit_overrides=$(grep -cvE '^\s*(#|$)' "${SCRIPT_DIR}/step_limits.yml" 2>/dev/null || true)  # entries in benchmarks/robotwin/step_limits.yml; 0 = RoboTwin upstream limits
+policy_config=${POLICY_CONFIG_PATH:-${SCRIPT_DIR}/policy_config.yml}
+robotwin_path=${ROBOTWIN_PATH:-}
+robotwin_commit=$(_git_head "${ROBOTWIN_PATH:-/nonexistent}")
+openwam_commit=$(_git_head "${SCRIPT_DIR}")
+tasks=${TASKS[*]}
+EOF
+
 echo "[INFO] mode=${TASK_CONFIG}  name=${POLICY_NAME}"
 echo "[INFO] server=ws://${SERVER_HOST}:${PORT}  gpu=${GPU_ID}"
 echo "[INFO] ckpt_dir=${CKPT_DIR}"

--- a/benchmarks/robotwin/single_eval.sh
+++ b/benchmarks/robotwin/single_eval.sh
@@ -40,7 +40,10 @@ port="${5:-${ROBOTWIN_PORT:-8848}}"
 host="${6:-${ROBOTWIN_POLICY_HOST:-127.0.0.1}}"
 seed="0"
 
-robotwin_python="${ROBOTWIN_PYTHON:-python}"
+# Fail fast: silently falling back to the current `python` (usually the OpenWAM
+# env) only surfaces much later as a SAPIEN/RoboTwin import error.
+robotwin_python="${ROBOTWIN_PYTHON:?ROBOTWIN_PYTHON must point to the RoboTwin env python (e.g. /path/to/miniconda3/envs/robotwin/bin/python)}"
+[[ -x "${robotwin_python}" ]] || { echo "[ERROR] ROBOTWIN_PYTHON is not executable: ${robotwin_python}" >&2; exit 1; }
 policy_config_template="${POLICY_CONFIG_PATH:-${SCRIPT_DIR}/policy_config.yml}"
 
 [[ -f "${policy_config_template}" ]] || {

--- a/openwam/deploy/model_loader.py
+++ b/openwam/deploy/model_loader.py
@@ -130,8 +130,13 @@ def load_from_checkpoint_dir(
         # ``ListConfig`` whose entries are ``DictConfig`` (NOT a ``dict``
         # subclass) — so ``isinstance(c, dict)`` would always be False
         # against the real saved config, silently skipping the marker.
+        # Require the ``source: state_dict`` marker, not just ``attr``: Wan
+        # checkpoints also carry a ``text_encoder`` component (umt5, an
+        # instantiation spec with ``model_class``), and matching on ``attr``
+        # alone logged a phantom ``<ckpt>/reason1`` dir for every Wan deploy.
         has_reason1_state_component = any(
-            isinstance(c, dict) and c.get("attr") == "text_encoder" for c in (vb_cfg_dict.get("components") or [])
+            isinstance(c, dict) and c.get("attr") == "text_encoder" and c.get("source") == "state_dict"
+            for c in (vb_cfg_dict.get("components") or [])
         )
         if has_reason1_state_component:
             prev_path = vb_cfg_dict.get("text_encoder_path")

--- a/openwam/deploy/model_loader.py
+++ b/openwam/deploy/model_loader.py
@@ -130,10 +130,8 @@ def load_from_checkpoint_dir(
         # ``ListConfig`` whose entries are ``DictConfig`` (NOT a ``dict``
         # subclass) — so ``isinstance(c, dict)`` would always be False
         # against the real saved config, silently skipping the marker.
-        # Require the ``source: state_dict`` marker, not just ``attr``: Wan
-        # checkpoints also carry a ``text_encoder`` component (umt5, an
-        # instantiation spec with ``model_class``), and matching on ``attr``
-        # alone logged a phantom ``<ckpt>/reason1`` dir for every Wan deploy.
+        # ``source: state_dict`` distinguishes the Reason1 marker from Wan's
+        # umt5 ``text_encoder`` component (a ``model_class`` instantiation spec).
         has_reason1_state_component = any(
             isinstance(c, dict) and c.get("attr") == "text_encoder" and c.get("source") == "state_dict"
             for c in (vb_cfg_dict.get("components") or [])

--- a/scripts/download_assets/download_benchmark_data.py
+++ b/scripts/download_assets/download_benchmark_data.py
@@ -364,12 +364,24 @@ _POST_DOWNLOAD = {
 }
 
 
+_RELOCATED_MARKER = ".relocated"
+
+
 def _already_relocated(bench: Benchmark, target: Path) -> bool:
-    """A strip_prefix benchmark whose content already sits at the folder root."""
+    """A strip_prefix benchmark whose relocation finished in an earlier run.
+
+    Requires the download scaffold (``<target>/<strip_prefix top>``) to be gone:
+    an interrupted relocation leaves it behind, and that run must resume the
+    download and finish moving files rather than be taken as complete.
+    """
     if bench.strip_prefix is None or not target.is_dir():
         return False
-    children = {c.name for c in target.iterdir()} - {".cache", "data"}
-    return bool(children)
+    if (target / bench.strip_prefix.split("/")[0]).exists():
+        return False
+    if (target / _RELOCATED_MARKER).is_file():
+        return True
+    # Relocated by an earlier version that did not write the marker.
+    return bool({c.name for c in target.iterdir()} - {".cache"})
 
 
 def _relocate(bench: Benchmark, target: Path) -> None:
@@ -385,9 +397,12 @@ def _relocate(bench: Benchmark, target: Path) -> None:
             print(yellow(f"  {dest} already exists — keeping it, skipping the fresh copy."))
             continue
         shutil.move(str(child), str(dest))
-    # Drop the now-empty scaffold (data/RoboDojo[/…]).
+    # Drop the now-empty scaffold (data/RoboDojo[/…]) and mark the relocation
+    # complete; the marker is only written once the scaffold is gone.
     top = target / bench.strip_prefix.split("/")[0]
     shutil.rmtree(top, ignore_errors=True)
+    if not top.exists():
+        (target / _RELOCATED_MARKER).write_text(f"{bench.strip_prefix}\n", encoding="utf-8")
 
 
 def download(bench: Benchmark, root: Path, expected: int) -> Path:

--- a/scripts/download_assets/download_benchmark_data.py
+++ b/scripts/download_assets/download_benchmark_data.py
@@ -8,6 +8,7 @@ openwam/dataloader/utils/stats_computation/ when they are missing.
 
 Usage:
     python scripts/download_assets/download_benchmark_data.py
+    python scripts/download_assets/download_benchmark_data.py --name RoboTwin2.0 --yes   # non-interactive; omitted flags are asked
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ import os
 # Must be set before huggingface_hub is imported anywhere.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
+import argparse
 import re
 import shutil
 import subprocess
@@ -31,7 +33,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_DIR = REPO_ROOT / "configs" / "dataloader"
-DEFAULT_ROOT = Path.cwd() / "assets" / "benchmark_data"
+DEFAULT_ROOT = REPO_ROOT / "assets" / "benchmark_data"
 
 # ── terminal colors ──────────────────────────────────────────────────────────
 _USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
@@ -172,7 +174,11 @@ def ask_yes_no(prompt: str, default_yes: bool) -> bool:
 
 
 # ── steps ────────────────────────────────────────────────────────────────────
-def choose_storage_root() -> Path:
+def choose_storage_root(preset: str | None = None, use_default: bool = False) -> Path:
+    if preset or use_default:
+        root = Path(preset).expanduser() if preset else DEFAULT_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        return root
     print(bold("Storage location"))
     print(f"  Default: {DEFAULT_ROOT}")
     answer = ask("Storage path (press Enter for the default): ")
@@ -189,7 +195,15 @@ def choose_storage_root() -> Path:
     return root
 
 
-def choose_benchmark() -> Benchmark:
+def choose_benchmark(preset: str | None = None) -> Benchmark:
+    if preset:
+        for b in BENCHMARKS.values():
+            if b.name.lower() == preset.lower():
+                return b
+        print(
+            red(f"Error: unknown benchmark {preset!r}. Choose from: " + ", ".join(b.name for b in BENCHMARKS.values()))
+        )
+        sys.exit(2)
     key = ask_choice(
         "Select the benchmark to download",
         [f"({k}) {b.name}" for k, b in BENCHMARKS.items()],
@@ -592,17 +606,30 @@ def write_config(bench: Benchmark, target: Path) -> None:
         print(yellow(f"Note: {bench.config_note}"))
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download benchmark data. Flags skip the matching menu step; omitted steps are asked interactively.",
+    )
+    parser.add_argument("--name", help="benchmark name, e.g. " + ", ".join(b.name for b in BENCHMARKS.values()))
+    parser.add_argument("--root", help=f"storage directory (default: {DEFAULT_ROOT})")
+    parser.add_argument(
+        "-y", "--yes", action="store_true", help="accept the default storage root and start without confirmation"
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
+    args = parse_args()
     print(bold("OpenWAM benchmark data downloader"))
     print()
-    root = choose_storage_root()
-    bench = choose_benchmark()
+    root = choose_storage_root(args.root, use_default=args.yes)
+    bench = choose_benchmark(args.name)
 
     expected, live = query_download_size(bench)
     origin = "" if live else " (approximate)"
     print()
     print(yellow(f"{bench.name} needs about {expected / 1e9:.1f} GB{origin} under {root}."))
-    if not ask_yes_no("Start the download? ", default_yes=True):
+    if not args.yes and not ask_yes_no("Start the download? ", default_yes=True):
         print(cyan("Aborted — nothing downloaded."))
         sys.exit(0)
 

--- a/scripts/download_assets/download_openwam_checkpoints.py
+++ b/scripts/download_assets/download_openwam_checkpoints.py
@@ -15,11 +15,18 @@ finetuning start (training.finetune_ckpt_path in configs/train.yaml), not
 for direct deployment.
 
 Usage:
-    python scripts/download_assets/download_openwam_checkpoints.py
+    python scripts/download_assets/download_openwam_checkpoints.py            # interactive menu
+    python scripts/download_assets/download_openwam_checkpoints.py \\
+        --family alpha --name OpenWAM-Alpha-Sim-RoboTwin-Full --yes         # non-interactive
+    python scripts/download_assets/download_openwam_checkpoints.py \\
+        --family study --study-type attention_mask --name robotwin_dual_system_joint_self_attention_mutual --yes
+
+Any menu step not covered by a flag is still asked interactively.
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 
 # HuggingFace downloads render their own stack of progress bars (including the
@@ -34,7 +41,8 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-ASSETS_ROOT = Path.cwd() / "assets" / "openwam_ckpt"
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ASSETS_ROOT = REPO_ROOT / "assets" / "openwam_ckpt"
 
 # ── terminal colors ──────────────────────────────────────────────────────────
 _USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
@@ -207,7 +215,32 @@ def ask_yes_no(prompt: str, default_yes: bool) -> bool:
 
 
 # ── steps ────────────────────────────────────────────────────────────────────
-def choose_group() -> Group:
+def _study_group_by_key(key: str) -> Group:
+    """Resolve ``--study-type`` given as a 1-based index or a (sub)string of the title."""
+    if key.isdigit() and 1 <= int(key) <= len(STUDY_GROUPS):
+        return STUDY_GROUPS[int(key) - 1]
+    needle = key.lower().replace("-", "_").replace(" ", "_")
+    matches = [g for g in STUDY_GROUPS if needle in g.title.lower().replace("-", "_").replace(" ", "_")]
+    if len(matches) == 1:
+        return matches[0]
+    print(red(f"Error: --study-type {key!r} does not identify one study type. Choose from:"))
+    for i, g in enumerate(STUDY_GROUPS, 1):
+        print(f"  ({i}) {g.title}")
+    sys.exit(2)
+
+
+def choose_group(family: str | None = None, study_type: str | None = None) -> Group:
+    if family == "alpha":
+        return ALPHA
+    if family == "study" and study_type:
+        return _study_group_by_key(study_type)
+    if family == "study":
+        type_key = ask_choice(
+            "Select the study type",
+            [f"({i}) {g.title}" for i, g in enumerate(STUDY_GROUPS, 1)],
+            "Type number: ",
+        )
+        return STUDY_GROUPS[int(type_key) - 1]
     key = ask_choice(
         "Select the checkpoint family",
         [
@@ -226,8 +259,12 @@ def choose_group() -> Group:
     return STUDY_GROUPS[int(type_key) - 1]
 
 
-def choose_storage_root(group: Group) -> Path:
+def choose_storage_root(group: Group, preset: str | None = None, use_default: bool = False) -> Path:
     default_root = ASSETS_ROOT / group.subdir
+    if preset or use_default:
+        root = Path(preset).expanduser() if preset else default_root
+        root.mkdir(parents=True, exist_ok=True)
+        return root
     print()
     print(bold("Storage location"))
     print(f"  Default: {default_root}")
@@ -245,7 +282,15 @@ def choose_storage_root(group: Group) -> Path:
     return root
 
 
-def choose_ckpt(group: Group) -> Ckpt:
+def choose_ckpt(group: Group, preset: str | None = None) -> Ckpt:
+    if preset:
+        for c in group.ckpts:
+            if c.name.lower() == preset.lower():
+                return c
+        print(red(f"Error: no checkpoint named {preset!r} in {group.title}. Choose from:"))
+        for c in group.ckpts:
+            print(f"  {c.name}")
+        sys.exit(2)
     key = ask_choice(
         f"Select the checkpoint to download from {group.title}",
         [f"({i}) {c.label}" for i, c in enumerate(group.ckpts, 1)],
@@ -338,18 +383,37 @@ def final_hint(ckpt: Ckpt, target: Path) -> list[str]:
     return [f"Deploy it with: {bold(f'bash scripts/deploy.sh {target}')}"]
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download a released OpenWAM checkpoint. Flags skip the matching menu step; "
+        "omitted steps are asked interactively.",
+    )
+    parser.add_argument("--family", choices=("alpha", "study"), help="checkpoint family")
+    parser.add_argument("--study-type", help="study type (1-based index or part of its title); implies --family study")
+    parser.add_argument("--name", help="checkpoint name, e.g. OpenWAM-Alpha-Sim-RoboTwin-Full")
+    parser.add_argument("--root", help=f"storage directory (default: {ASSETS_ROOT}/<family subdir>)")
+    parser.add_argument(
+        "-y", "--yes", action="store_true", help="accept the default storage root and start without confirmation"
+    )
+    args = parser.parse_args(argv)
+    if args.study_type and not args.family:
+        args.family = "study"
+    return args
+
+
 def main() -> None:
+    args = parse_args()
     print(bold("OpenWAM released-checkpoint downloader"))
     print()
-    group = choose_group()
-    root = choose_storage_root(group)
-    ckpt = choose_ckpt(group)
+    group = choose_group(args.family, args.study_type)
+    root = choose_storage_root(group, args.root, use_default=args.yes)
+    ckpt = choose_ckpt(group, args.name)
 
     expected, live = query_download_size(ckpt)
     origin = "" if live else " (approximate)"
     print()
     print(yellow(f"{ckpt.label} needs about {expected / 1e9:.1f} GB{origin} under {root}."))
-    if not ask_yes_no("Start the download? ", default_yes=True):
+    if not args.yes and not ask_yes_no("Start the download? ", default_yes=True):
         print(cyan("Aborted — nothing downloaded."))
         sys.exit(0)
 

--- a/scripts/download_assets/download_video_backbone.py
+++ b/scripts/download_assets/download_video_backbone.py
@@ -8,6 +8,7 @@ training picks it up without manual editing.
 
 Usage:
     python scripts/download_assets/download_video_backbone.py
+    python scripts/download_assets/download_video_backbone.py --name Wan2.2-TI2V-5B --source huggingface --yes   # non-interactive; omitted flags are asked
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ import os
 # Must be set before huggingface_hub is imported anywhere.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
+import argparse
 import re
 import sys
 import threading
@@ -29,7 +31,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_DIR = REPO_ROOT / "configs" / "model" / "video_backbone"
-DEFAULT_ROOT = Path.cwd() / "assets" / "video_backbone_ckpt"
+DEFAULT_ROOT = REPO_ROOT / "assets" / "video_backbone_ckpt"
 
 # ── terminal colors ──────────────────────────────────────────────────────────
 _USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
@@ -151,7 +153,11 @@ def ask_yes_no(prompt: str, default_yes: bool) -> bool:
 
 
 # ── steps ────────────────────────────────────────────────────────────────────
-def choose_storage_root() -> Path:
+def choose_storage_root(preset: str | None = None, use_default: bool = False) -> Path:
+    if preset or use_default:
+        root = Path(preset).expanduser() if preset else DEFAULT_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        return root
     print(bold("Storage location"))
     print(f"  Default: {DEFAULT_ROOT}")
     answer = ask("Storage path (press Enter for the default): ")
@@ -168,7 +174,13 @@ def choose_storage_root() -> Path:
     return root
 
 
-def choose_model() -> Model:
+def choose_model(preset: str | None = None) -> Model:
+    if preset:
+        for m in MODELS.values():
+            if m.name.lower() == preset.lower():
+                return m
+        print(red(f"Error: unknown model {preset!r}. Choose from: " + ", ".join(m.name for m in MODELS.values())))
+        sys.exit(2)
     key = ask_choice(
         "Select the model to download",
         [f"({k}) {m.name}" for k, m in MODELS.items()],
@@ -177,7 +189,12 @@ def choose_model() -> Model:
     return MODELS[key]
 
 
-def choose_source(model: Model) -> str:
+def choose_source(model: Model, preset: str | None = None) -> str:
+    if preset:
+        if preset == "modelscope" and model.hf_only:
+            print(yellow(f"{model.name} is not available on ModelScope; downloading from HuggingFace instead."))
+            return "huggingface"
+        return preset
     key = ask_choice(
         "Select the download source",
         ["(1) huggingface", "(2) modelscope"],
@@ -307,18 +324,35 @@ def write_config(model: Model, targets: list[Path]) -> None:
     config_path.write_text(text, encoding="utf-8")
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download a video backbone. Flags skip the matching menu step; omitted steps are asked interactively.",
+    )
+    parser.add_argument("--name", help="model name, e.g. " + ", ".join(m.name for m in MODELS.values()))
+    parser.add_argument("--source", choices=("huggingface", "modelscope"), help="download source")
+    parser.add_argument("--root", help=f"storage directory (default: {DEFAULT_ROOT})")
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="accept defaults (storage root, huggingface source) and start without confirmation",
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
+    args = parse_args()
     print(bold("OpenWAM video-backbone checkpoint downloader"))
     print()
-    root = choose_storage_root()
-    model = choose_model()
-    source = choose_source(model)
+    root = choose_storage_root(args.root, use_default=args.yes)
+    model = choose_model(args.name)
+    source = choose_source(model, args.source or ("huggingface" if args.yes else None))
 
     sizes, live = query_download_sizes(model, source)
     origin = "" if live else " (approximate)"
     print()
     print(yellow(f"{model.name} needs about {sum(sizes) / 1e9:.1f} GB{origin} under {root}."))
-    if not ask_yes_no("Start the download? ", default_yes=True):
+    if not args.yes and not ask_yes_no("Start the download? ", default_yes=True):
         print(cyan("Aborted — nothing downloaded."))
         sys.exit(0)
 

--- a/scripts/download_assets/download_visual_encoder.py
+++ b/scripts/download_assets/download_visual_encoder.py
@@ -9,6 +9,7 @@ without manual editing.
 
 Usage:
     python scripts/download_assets/download_visual_encoder.py
+    python scripts/download_assets/download_visual_encoder.py --name dinov3-vitb16-pretrain-lvd1689m --source modelscope --yes   # non-interactive; omitted flags are asked
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ import os
 # Must be set before huggingface_hub is imported anywhere.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
+import argparse
 import json
 import re
 import sys
@@ -31,7 +33,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_DIR = REPO_ROOT / "configs" / "model" / "video_backbone" / "encoder"
-DEFAULT_ROOT = Path.cwd() / "assets" / "visual_encoder_ckpt"
+DEFAULT_ROOT = REPO_ROOT / "assets" / "visual_encoder_ckpt"
 
 VJEPA_MANIFEST = {
     "arch_name": "vit_giant_xformers_rope",
@@ -160,7 +162,11 @@ def ask_yes_no(prompt: str, default_yes: bool) -> bool:
 
 
 # ── steps ────────────────────────────────────────────────────────────────────
-def choose_storage_root() -> Path:
+def choose_storage_root(preset: str | None = None, use_default: bool = False) -> Path:
+    if preset or use_default:
+        root = Path(preset).expanduser() if preset else DEFAULT_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        return root
     print(bold("Storage location"))
     print(f"  Default: {DEFAULT_ROOT}")
     answer = ask("Storage path (press Enter for the default): ")
@@ -177,7 +183,13 @@ def choose_storage_root() -> Path:
     return root
 
 
-def choose_model() -> Model:
+def choose_model(preset: str | None = None) -> Model:
+    if preset:
+        for m in MODELS.values():
+            if m.name.lower() == preset.lower():
+                return m
+        print(red(f"Error: unknown model {preset!r}. Choose from: " + ", ".join(m.name for m in MODELS.values())))
+        sys.exit(2)
     key = ask_choice(
         "Select the model to download",
         [f"({k}) {m.name}" for k, m in MODELS.items()],
@@ -186,7 +198,7 @@ def choose_model() -> Model:
     return MODELS[key]
 
 
-def choose_source(model: Model) -> str:
+def choose_source(model: Model, preset: str | None = None) -> str:
     if model.direct_url:
         print()
         print(
@@ -196,6 +208,12 @@ def choose_source(model: Model) -> str:
             )
         )
         return "direct"
+    if preset:
+        if preset == "huggingface" and model.hf_gated:
+            print(
+                yellow(f"Note: on HuggingFace this repo is {model.hf_gated}; ModelScope hosts the same files ungated.")
+            )
+        return preset
     key = ask_choice(
         "Select the download source",
         ["(1) huggingface", "(2) modelscope"],
@@ -360,18 +378,37 @@ def write_config(model: Model, target: Path) -> None:
     print(green(f"Updated {rel}: model_path -> {value}"))
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download a visual encoder. Flags skip the matching menu step; omitted steps are asked interactively.",
+    )
+    parser.add_argument("--name", help="model name, e.g. " + ", ".join(m.name for m in MODELS.values()))
+    parser.add_argument(
+        "--source", choices=("huggingface", "modelscope"), help="download source (ignored for direct-URL models)"
+    )
+    parser.add_argument("--root", help=f"storage directory (default: {DEFAULT_ROOT})")
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="accept defaults (storage root, huggingface source) and start without confirmation",
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
+    args = parse_args()
     print(bold("OpenWAM visual-encoder checkpoint downloader"))
     print()
-    root = choose_storage_root()
-    model = choose_model()
-    source = choose_source(model)
+    root = choose_storage_root(args.root, use_default=args.yes)
+    model = choose_model(args.name)
+    source = choose_source(model, args.source or ("huggingface" if args.yes else None))
 
     expected, live = query_size_bytes(model, source)
     origin = "" if live else " (approximate)"
     print()
     print(yellow(f"{model.name} needs about {expected / 1e9:.1f} GB{origin} under {root}."))
-    if not ask_yes_no("Start the download? ", default_yes=True):
+    if not args.yes and not ask_yes_no("Start the download? ", default_yes=True):
         print(cyan("Aborted — nothing downloaded."))
         sys.exit(0)
 

--- a/scripts/download_assets/download_vlm_backbone.py
+++ b/scripts/download_assets/download_vlm_backbone.py
@@ -8,6 +8,7 @@ download so training picks it up without manual editing.
 
 Usage:
     python scripts/download_assets/download_vlm_backbone.py
+    python scripts/download_assets/download_vlm_backbone.py --name Qwen3-VL-2B-Instruct --source huggingface --yes   # non-interactive; omitted flags are asked
 """
 
 from __future__ import annotations
@@ -20,6 +21,7 @@ import os
 # Must be set before huggingface_hub is imported anywhere.
 os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
 
+import argparse
 import re
 import sys
 import threading
@@ -29,7 +31,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CONFIG_DIR = REPO_ROOT / "configs" / "model" / "vlm_backbone"
-DEFAULT_ROOT = Path.cwd() / "assets" / "vlm_backbone_ckpt"
+DEFAULT_ROOT = REPO_ROOT / "assets" / "vlm_backbone_ckpt"
 
 # ── terminal colors ──────────────────────────────────────────────────────────
 _USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
@@ -118,7 +120,11 @@ def ask_yes_no(prompt: str, default_yes: bool) -> bool:
 
 
 # ── steps ────────────────────────────────────────────────────────────────────
-def choose_storage_root() -> Path:
+def choose_storage_root(preset: str | None = None, use_default: bool = False) -> Path:
+    if preset or use_default:
+        root = Path(preset).expanduser() if preset else DEFAULT_ROOT
+        root.mkdir(parents=True, exist_ok=True)
+        return root
     print(bold("Storage location"))
     print(f"  Default: {DEFAULT_ROOT}")
     answer = ask("Storage path (press Enter for the default): ")
@@ -135,7 +141,13 @@ def choose_storage_root() -> Path:
     return root
 
 
-def choose_model() -> Model:
+def choose_model(preset: str | None = None) -> Model:
+    if preset:
+        for m in MODELS.values():
+            if m.name.lower() == preset.lower():
+                return m
+        print(red(f"Error: unknown model {preset!r}. Choose from: " + ", ".join(m.name for m in MODELS.values())))
+        sys.exit(2)
     key = ask_choice(
         "Select the model to download",
         [f"({k}) {m.name}" for k, m in MODELS.items()],
@@ -144,7 +156,12 @@ def choose_model() -> Model:
     return MODELS[key]
 
 
-def choose_source(model: Model) -> str:
+def choose_source(model: Model, preset: str | None = None) -> str:
+    if preset:
+        if preset == "modelscope" and model.hf_only:
+            print(yellow(f"{model.name} is not available on ModelScope; downloading from HuggingFace instead."))
+            return "huggingface"
+        return preset
     key = ask_choice(
         "Select the download source",
         ["(1) huggingface", "(2) modelscope"],
@@ -274,18 +291,35 @@ def write_config(model: Model, targets: list[Path]) -> None:
     config_path.write_text(text, encoding="utf-8")
 
 
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download a VLM backbone. Flags skip the matching menu step; omitted steps are asked interactively.",
+    )
+    parser.add_argument("--name", help="model name, e.g. " + ", ".join(m.name for m in MODELS.values()))
+    parser.add_argument("--source", choices=("huggingface", "modelscope"), help="download source")
+    parser.add_argument("--root", help=f"storage directory (default: {DEFAULT_ROOT})")
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="accept defaults (storage root, huggingface source) and start without confirmation",
+    )
+    return parser.parse_args(argv)
+
+
 def main() -> None:
+    args = parse_args()
     print(bold("OpenWAM VLM-backbone checkpoint downloader"))
     print()
-    root = choose_storage_root()
-    model = choose_model()
-    source = choose_source(model)
+    root = choose_storage_root(args.root, use_default=args.yes)
+    model = choose_model(args.name)
+    source = choose_source(model, args.source or ("huggingface" if args.yes else None))
 
     sizes, live = query_download_sizes(model, source)
     origin = "" if live else " (approximate)"
     print()
     print(yellow(f"{model.name} needs about {sum(sizes) / 1e9:.1f} GB{origin} under {root}."))
-    if not ask_yes_no("Start the download? ", default_yes=True):
+    if not args.yes and not ask_yes_no("Start the download? ", default_yes=True):
         print(cyan("Aborted — nothing downloaded."))
         sys.exit(0)
 

--- a/tests/_assets.py
+++ b/tests/_assets.py
@@ -1,0 +1,39 @@
+"""Locate real model weights for GPU tests.
+
+Each asset is resolved in this order:
+
+1. its ``OPENWAM_<ASSET>`` environment variable,
+2. the legacy variable names some tests used before the names were unified,
+3. the directory ``scripts/download_assets/`` writes to by default.
+
+So after downloading with the repo scripts nothing needs to be exported; point
+the variable elsewhere only for weights stored outside ``assets/``. Tests skip
+(or are deselected via ``-m "not gpu"``) when the resolved path does not exist.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_VIDEO_BACKBONES = PROJECT_ROOT / "assets" / "video_backbone_ckpt"
+
+# canonical env var -> (legacy env vars, default location written by the downloader)
+_ASSETS: dict[str, tuple[tuple[str, ...], Path]] = {
+    "OPENWAM_WAN22_TI2V_5B": (("WAN22_TI2V_5B", "WAN_TI2V_5B_PATH"), _VIDEO_BACKBONES / "Wan2.2-TI2V-5B"),
+    "OPENWAM_WAN21_VACE_1_3B": (("WAN21_VACE_1_3B",), _VIDEO_BACKBONES / "Wan2.1-VACE-1.3B"),
+    "OPENWAM_COSMOS25_2B": (("COSMOS25_ASSET_PATH",), _VIDEO_BACKBONES / "Cosmos-Predict2.5-2B"),
+    "OPENWAM_COSMOS_REASON1_7B": (("REASON1_ASSET_PATH",), _VIDEO_BACKBONES / "Cosmos-Reason1-7B"),
+    "OPENWAM_COSMOS3_EDGE": (("COSMOS3_EDGE_ASSET_PATH",), _VIDEO_BACKBONES / "Cosmos3-Edge"),
+}
+
+
+def asset_path(name: str) -> str:
+    """Return the on-disk location for ``name`` (a key of ``_ASSETS``)."""
+    legacy, default = _ASSETS[name]
+    for var in (name, *legacy):
+        value = os.environ.get(var)
+        if value:
+            return value
+    return str(default)

--- a/tests/test_cosmos3_real_load.py
+++ b/tests/test_cosmos3_real_load.py
@@ -5,15 +5,16 @@ geometry, runs preprocess_input_for_train end-to-end on synthetic PIL frames,
 drives the full 28-block loop shape-conservingly, and round-trips the VAE.
 """
 
-import os
 from pathlib import Path
 
 import pytest
 import torch
 
+from tests._assets import asset_path
+
 pytestmark = pytest.mark.gpu
 
-ASSET_PATH = Path(os.environ.get("COSMOS3_EDGE_ASSET_PATH", "/path/to/assets/Cosmos3-Edge"))
+ASSET_PATH = Path(asset_path("OPENWAM_COSMOS3_EDGE"))
 
 
 def _skip_unless_runnable():

--- a/tests/test_cosmos_predict25_joint_cross_attn.py
+++ b/tests/test_cosmos_predict25_joint_cross_attn.py
@@ -36,9 +36,10 @@ import os
 import pytest
 import torch
 
+from tests._assets import asset_path
 from tests.test_cosmos_predict25_joint_self_attn import _build_rich_wrapper
 
-COSMOS25_2B = os.environ.get("OPENWAM_COSMOS25_2B", "/path/to/assets/Cosmos-Predict2.5-2B")
+COSMOS25_2B = asset_path("OPENWAM_COSMOS25_2B")
 
 
 def _make_cosmos_cross_attn(num_blocks=2, *, action_dim=3, text_dim=12):

--- a/tests/test_cosmos_predict25_real_inference.py
+++ b/tests/test_cosmos_predict25_real_inference.py
@@ -11,15 +11,16 @@ Skip conditions identical to ``test_cosmos_predict25_real_load.py``.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
 import torch
 
+from tests._assets import asset_path
+
 pytestmark = pytest.mark.gpu
 
-ASSET_PATH = Path(os.environ.get("COSMOS25_ASSET_PATH", "/path/to/assets/Cosmos-Predict2.5-2B"))
+ASSET_PATH = Path(asset_path("OPENWAM_COSMOS25_2B"))
 
 
 def _skip_unless_runnable():

--- a/tests/test_cosmos_predict25_real_load.py
+++ b/tests/test_cosmos_predict25_real_load.py
@@ -18,15 +18,16 @@ Annotated ``@pytest.mark.gpu``; explicit invocation:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import pytest
 import torch
 
+from tests._assets import asset_path
+
 pytestmark = pytest.mark.gpu
 
-ASSET_PATH = Path(os.environ.get("COSMOS25_ASSET_PATH", "/path/to/assets/Cosmos-Predict2.5-2B"))
+ASSET_PATH = Path(asset_path("OPENWAM_COSMOS25_2B"))
 
 
 def _skip_unless_runnable():

--- a/tests/test_cosmos_predict25_tri_system.py
+++ b/tests/test_cosmos_predict25_tri_system.py
@@ -40,9 +40,10 @@ import pytest
 import torch
 import torch.nn as nn
 
+from tests._assets import asset_path
 from tests.test_cosmos_predict25_joint_self_attn import _build_rich_wrapper
 
-COSMOS25_2B = os.environ.get("OPENWAM_COSMOS25_2B", "/path/to/assets/Cosmos-Predict2.5-2B")
+COSMOS25_2B = asset_path("OPENWAM_COSMOS25_2B")
 
 
 def _make_tri_arch(vb, *, action_dim=7, action_res_dim=24, und_dim=16, vlm_input_dim=20, device=None):

--- a/tests/test_reason1_text_encoder.py
+++ b/tests/test_reason1_text_encoder.py
@@ -15,6 +15,7 @@ import torch
 
 from openwam.model.video_backbone.cosmos_predict25 import text_encoder as te
 from openwam.model.video_backbone.cosmos_predict25.text_encoder import Reason1LiveTextEncoder
+from tests._assets import asset_path
 
 
 def test_constants_match_upstream_geometry():
@@ -108,7 +109,7 @@ def test_validate_geometry_rejects_wrong_layer_count():
 # Reason1 real-load smoke — only runs when Reason1 weights AND CUDA exist.
 # ----------------------------------------------------------------------
 
-REASON1_ASSET_PATH = os.environ.get("REASON1_ASSET_PATH", "/path/to/assets/Cosmos-Reason1-7B")
+REASON1_ASSET_PATH = asset_path("OPENWAM_COSMOS_REASON1_7B")
 
 
 @pytest.mark.gpu

--- a/tests/test_tri_system_smoke.py
+++ b/tests/test_tri_system_smoke.py
@@ -30,8 +30,9 @@ from openwam.model.video_backbone.base import BlockLoopState
 from openwam.model.video_backbone.wan.models.dit import DiTBlock
 from openwam.model.video_backbone.wan_backbone import Wan21
 from openwam.model.vlm_backbone import Qwen3VLBackbone
+from tests._assets import asset_path
 
-WAN22_TI2V_5B = os.environ.get("OPENWAM_WAN22_TI2V_5B", "/path/to/Wan2.2-TI2V-5B")
+WAN22_TI2V_5B = asset_path("OPENWAM_WAN22_TI2V_5B")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_video_backbone_consistency.py
+++ b/tests/test_video_backbone_consistency.py
@@ -21,12 +21,13 @@ from safetensors.torch import load_file
 
 from openwam.model.video_backbone.wan._reference import model_fn_wan_video
 from openwam.model.video_backbone.wan_backbone import Wan21
+from tests._assets import asset_path
 
 # Override via env vars on machines that mount the checkpoints elsewhere; the
 # defaults match the shared dev box but skipif() makes a missing path a skip,
 # not a hard failure.
-WAN21_VACE_1_3B = os.environ.get("WAN21_VACE_1_3B", "/path/to/Wan2.1-VACE-1.3B")
-WAN22_TI2V_5B = os.environ.get("WAN22_TI2V_5B", "/path/to/Wan2.2-TI2V-5B")
+WAN21_VACE_1_3B = asset_path("OPENWAM_WAN21_VACE_1_3B")
+WAN22_TI2V_5B = asset_path("OPENWAM_WAN22_TI2V_5B")
 CUDA_AVAILABLE = torch.cuda.is_available()
 
 

--- a/tests/test_video_backbone_from_scratch.py
+++ b/tests/test_video_backbone_from_scratch.py
@@ -23,6 +23,7 @@ import torch
 
 from openwam.model.video_backbone.wan.models.dit import RMSNorm, WanModel
 from openwam.model.video_backbone.wan.reinit import reinit_dit_from_scratch
+from tests._assets import asset_path
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -364,7 +365,7 @@ model:
 training:
   initialize_model_on_cpu: true
 """
-    model_path = os.environ.get("WAN_TI2V_5B_PATH", "/path/to/Wan2.2-TI2V-5B")
+    model_path = asset_path("OPENWAM_WAN22_TI2V_5B")
     if not os.path.isdir(model_path):
         pytest.skip(f"Wan2.2-TI2V-5B not found at {model_path}")
 
@@ -466,7 +467,7 @@ model:
 training:
   initialize_model_on_cpu: true
 """
-    model_path = os.environ.get("WAN_TI2V_5B_PATH", "/path/to/Wan2.2-TI2V-5B")
+    model_path = asset_path("OPENWAM_WAN22_TI2V_5B")
     if not os.path.isdir(model_path):
         pytest.skip(f"Wan2.2-TI2V-5B not found at {model_path}")
 


### PR DESCRIPTION
## Why

Walking the RoboTwin evaluation from a clean machine using only the docs works, but a few things make results hard to reproduce or the tooling hard to script:

- The adapter is tied to a specific RoboTwin / cuRobo / warp combination (it loads `script/eval_policy.py` by path and patches it), but no version was pinned and the startup workarounds were only explained in code comments.
- The Results tables did not state the evaluation protocol (DiT velocity cache is on by default in `deploy.yaml`, which changes the numbers).
- `single_eval.sh` silently fell back to whatever `python` was on PATH when `ROBOTWIN_PYTHON` was unset; the error then surfaced much later at SAPIEN import.
- Every Wan deploy logged `Using self-contained Reason1 artifacts from <ckpt>/reason1` for a directory that does not exist.
- The asset downloaders were menu-only and resolved `assets/` from the working directory.
- GPU tests used three different environment variable names for the same Wan2.2 weights, none documented.

## What

- **benchmarks/robotwin/README.md** — "Verified versions" table (RoboTwin `0aeea2d`, SAPIEN 3.0.0b1, cuRobo v0.7.8, warp-lang 1.13.0, mplib 0.2.1), an evaluation-protocol paragraph under Results, troubleshooting notes that explain each startup workaround, and an xvfb hint that only applies when SAPIEN actually fails.
- **eval_policy_wrapper.py** — warns when the RoboTwin checkout is not at the verified commit (`ROBOTWIN_SKIP_VERSION_CHECK=1` silences).
- **multi_eval.sh** — writes `run.env` (mode, seed, test_num, step-limit overrides, RoboTwin/OpenWAM commits, tasks) next to the logs.
- **single_eval.sh** — `ROBOTWIN_PYTHON` is required.
- **openwam/deploy/model_loader.py** — the Reason1 branch now requires the `source: state_dict` marker, so Wan checkpoints no longer trigger it.
- **scripts/download_assets/** — `--name`, `--source`, `--root`, `--yes` on every downloader (`--family` / `--study-type` for released checkpoints); omitted steps are still asked interactively; default storage root resolved from the repository.
- **tests/_assets.py** — single lookup for GPU-test weights: `OPENWAM_<ASSET>` env var → legacy names → the downloader's default directory. Documented in CONTRIBUTING under "Running GPU tests".
- **README.md** — note that `deepspeed` compiles from source (gcc).

## Verification

On an 8×H20 node with the released `OpenWAM-Alpha-Sim-RoboTwin-Full` checkpoint:

- `ruff check` / `ruff format --check` clean; `make test`: 1888 passed, 19 deselected.
- `download_openwam_checkpoints.py --family alpha --name OpenWAM-Alpha-Sim-RoboTwin-Full --yes` run from `/tmp` lands in the repo's `assets/`; unknown names exit 2 with the valid list; `--help` works on all five downloaders.
- `scripts/deploy.py` on the Wan checkpoint: no `Reason1` log line.
- `single_eval.sh` without `ROBOTWIN_PYTHON` fails immediately with the hint.
- `multi_eval.sh -m demo_clean … adjust_bottle` (1 episode): success, `run.env` written with the RoboTwin and OpenWAM commits.
- Version check: silent on the verified commit, warns on a non-git path.
