### PR TITLE
docs(benchmarks/libero,libero-plus): document the flags a real evaluation run needs

### DIFF
--- a/benchmarks/libero-plus/README.md
+++ b/benchmarks/libero-plus/README.md
@@ -58,10 +58,11 @@ LIBERO_PLUS_PYTHON=/path/to/miniconda3/envs/libero-plus/bin/python \
 LIBERO_PLUS_PATH=/path/to/LIBERO-plus \
 GPUS=0,1 REPLICAS_PER_GPU=1 \
 bash benchmarks/libero-plus/run_eval.sh \
-  assets/openwam_ckpt/openwam_alpha/OpenWAM-Alpha-Sim-LIBERO checkpoint_step_10000.safetensors
+  assets/openwam_ckpt/openwam_alpha/OpenWAM-Alpha-Sim-LIBERO checkpoint_step_10690.safetensors \
+  --compile-enabled false --render-gpus 2,3
 ```
 
-Append `--smoke` first for a one-task end-to-end validation. Single suite against the running server from section 2 (args: suite, task id, port, host):
+Append `--smoke` first for a one-task end-to-end validation. The two trailing flags are the defensive settings described under *Notes & troubleshooting* — drop them once you have confirmed your driver and PyTorch build do not need them. Single suite against the running server from section 2 (args: suite, task id, port, host):
 
 ```bash
 LIBERO_PLUS_PATH=/path/to/LIBERO-plus LIBERO_PLUS_PYTHON=/path/to/miniconda3/envs/libero-plus/bin/python \
@@ -74,6 +75,8 @@ bash benchmarks/libero-plus/single_eval.sh libero_spatial 0 8848 127.0.0.1
 - Always pass the checkpoint dir + filename explicitly (in-code defaults are placeholders); the dir must contain `config.yaml` and `normalization_stats.npy`, and the checkpoint must serve the `eef` representation. Substitute your actual `checkpoint_step_*.safetensors` name.
 - The official LIBERO-plus one-rollout protocol is pinned and validated at launch: **1 trial per task**, seed 10000, `rng_mode: official_global` (seeds the global RNGs, not the environment), settle 30, `max_steps` 600/700; deviations abort.
 - Managed replicas use ports from 8920; `single_eval.sh` defaults to `127.0.0.1:8848`.
+- **Client dies with `exit=-6` and a log that stops after the `[OpenWAMLiberoPolicy]` line.** MuJoCo's EGL offscreen renderer aborts inside `mjr_readPixels` when it shares a physical GPU with sustained CUDA compute — a driver-level conflict, not a LIBERO-plus or OpenWAM bug (reproduced on driver 570.124.06 by a bare `torch.matmul` loop in an unrelated process). Give the renderer its own GPUs with `--render-gpus`, e.g. `GPUS=0,1 ... --render-gpus 2,3`; the flag maps render devices onto policy-GPU slots and defaults to `--gpus`.
+- **Policy server dies with `Fatal Python error: none_dealloc: deallocating None`** inside a `torch._inductor` Triton launcher. Pass `--compile-enabled false` to run the server eager.
 - Resume: add `--output-dir outputs/libero-plus/<run_name>` and rerun the same command.
 - `summary.csv` / `summary.json` include per-task difficulty levels and per-perturbation-category breakdowns (the seven categories from `task_classification.json`).
 

--- a/benchmarks/libero-plus/setup_env.sh
+++ b/benchmarks/libero-plus/setup_env.sh
@@ -59,7 +59,15 @@ actual_commit="$(git -C "${LIBERO_PLUS_PATH}" rev-parse HEAD)"
 }
 git -C "${LIBERO_PLUS_PATH}" remote set-url origin "${LIBERO_PLUS_REMOTE}"
 
-if git -C "${LIBERO_PLUS_PATH}" apply --reverse --check "${LIBERO_PATCH}" >/dev/null 2>&1; then
+compatibility_patch_applied() {
+    [[ -f "${LIBERO_PLUS_PATH}/libero/__init__.py" ]] &&
+        grep -Fq 'weights_only=False' "${LIBERO_PLUS_PATH}/libero/libero/benchmark/__init__.py" &&
+        grep -Fq 'make_blob(format="PNG")' "${LIBERO_PLUS_PATH}/libero/libero/envs/env_wrapper.py" &&
+        grep -Fq 'bddl_file_name = str(bddl_file_name)' "${LIBERO_PLUS_PATH}/libero/libero/envs/env_wrapper.py"
+}
+
+if git -C "${LIBERO_PLUS_PATH}" apply --reverse --check "${LIBERO_PATCH}" >/dev/null 2>&1 ||
+    compatibility_patch_applied; then
     echo "[setup] LIBERO-plus compatibility patch already applied"
 elif git -C "${LIBERO_PLUS_PATH}" apply --check "${LIBERO_PATCH}" >/dev/null 2>&1; then
     git -C "${LIBERO_PLUS_PATH}" apply "${LIBERO_PATCH}"

--- a/benchmarks/libero/README.md
+++ b/benchmarks/libero/README.md
@@ -58,10 +58,11 @@ LIBERO_PYTHON=/path/to/miniconda3/envs/libero/bin/python \
 LIBERO_PATH=/path/to/LIBERO \
 GPUS=0,1 REPLICAS_PER_GPU=1 \
 bash benchmarks/libero/run_eval.sh \
-  assets/openwam_ckpt/openwam_alpha/OpenWAM-Alpha-Sim-LIBERO checkpoint_step_10000.safetensors
+  assets/openwam_ckpt/openwam_alpha/OpenWAM-Alpha-Sim-LIBERO checkpoint_step_10690.safetensors \
+  --compile-enabled false --render-gpus 2,3
 ```
 
-Append `--smoke` first for a one-task end-to-end validation. Single suite against the running server from section 2 (args: suite, task id, port, host):
+Append `--smoke` first for a one-task end-to-end validation. The two trailing flags are the defensive settings described under *Notes & troubleshooting* — drop them once you have confirmed your driver and PyTorch build do not need them. Single suite against the running server from section 2 (args: suite, task id, port, host):
 
 ```bash
 LIBERO_PATH=/path/to/LIBERO LIBERO_PYTHON=/path/to/miniconda3/envs/libero/bin/python \
@@ -73,6 +74,8 @@ bash benchmarks/libero/single_eval.sh libero_spatial 0 8848 127.0.0.1
 
 - Always pass the checkpoint dir + filename explicitly (in-code defaults are placeholders); the dir must contain `config.yaml` and `normalization_stats.npy`, and the checkpoint must serve the `eef` representation — the client pings and refuses mismatches. Substitute your actual `checkpoint_step_*.safetensors` name.
 - Protocol is pinned and validated at launch: 50 trials/task, seed 42, `max_steps` 600 (700 for `libero_10`); deviations abort.
+- **Client dies with `exit=-6` and a log that stops after the `[OpenWAMLiberoPolicy]` line.** MuJoCo's EGL offscreen renderer aborts inside `mjr_readPixels` when it shares a physical GPU with sustained CUDA compute — a driver-level conflict, not a LIBERO or OpenWAM bug (reproduced on driver 570.124.06 by a bare `torch.matmul` loop in an unrelated process). Give the renderer its own GPUs with `--render-gpus`, e.g. `GPUS=0,1 ... --render-gpus 2,3`; the flag maps render devices onto policy-GPU slots and defaults to `--gpus`.
+- **Policy server dies with `Fatal Python error: none_dealloc: deallocating None`** inside a `torch._inductor` Triton launcher. Pass `--compile-enabled false` to run the server eager.
 - Suites: `libero_spatial`, `libero_object`, `libero_goal`, `libero_10` (aliases `spatial|object|goal|long`). Managed replicas use ports from 8920.
 - Resume: add `--output-dir outputs/libero/<run_name>` and rerun the same command — completed tasks are skipped after a signature check.
 - Results land in the output dir: `summary.csv`, `summary.json`, `manifest.json`, per-task `results.json`, client/server logs.


### PR DESCRIPTION
## Summary

Rebuilding the `libero` and `libero-plus` conda environments from scratch and running the documented evaluation on an 8x H200 box turned up two failures that the READMEs do not cover. Both abort the run without an actionable message, so neither is diagnosable from the logs alone. No evaluation code changes were needed — the flags that fix them already exist in `scheduler.py`; only the documentation was missing.

## The two failure modes

**1. Client dies with `exit=-6`, log stops after the `[OpenWAMLiberoPolicy]` line**

MuJoCo's EGL offscreen renderer aborts inside `mjr_readPixels` when it shares a physical GPU with sustained CUDA compute. This is a driver-level conflict, not a LIBERO or OpenWAM bug — it reproduces on driver `570.124.06` with nothing but a `torch.matmul` loop running in an unrelated process on the same GPU, and a random-action rollout with no policy server at all is perfectly stable on an idle GPU.

`--render-gpus` already exists for exactly this. One additional constraint found the hard way: **one renderer per GPU**. Running `REPLICAS_PER_GPU=2` against 4 render GPUs puts two clients on each and aborts every task the same way.

**2. Policy server dies with `Fatal Python error: none_dealloc: deallocating None`**

Raised inside a `torch._inductor` Triton launcher. `--compile-enabled false` runs the server eager and avoids it.

## Changes

- Add `--compile-enabled false --render-gpus 2,3` to the primary `run_eval.sh` example in both READMEs, with a pointer to the troubleshooting notes so users can drop them once they confirm their own driver and PyTorch build do not need them.
- Add a troubleshooting bullet per failure mode, keyed on the symptom as it actually appears in the logs.
- Correct the example checkpoint filename `checkpoint_step_10000.safetensors` → `checkpoint_step_10690.safetensors`, which is what the release ships and what `scheduler.py` already carries as its default.
- `benchmarks/libero-plus/setup_env.sh`: fall back to a content probe when deciding whether the compatibility patch is already applied. `git apply --reverse --check` does not hold on a prepared checkout because the patch also creates `libero/__init__.py`, which stays untracked, so re-running setup aborted with "incompatible local changes" instead of being a no-op.

## Verification

Environments rebuilt from the READMEs; `run_smoke.sh import | task | env` passes for both benchmarks.

With the documented flags, using `OpenWAM-Alpha-Sim-LIBERO`:

| Benchmark | Scope | Result |
|---|---|---|
| LIBERO | `--task-sample-ratio 0.1`, official protocol (50 trials/task, seed 42) | spatial 50/50, goal 49/50, object 50/50, long 48/50 → **197/200 (98.5%)** |
| LIBERO | `libero_spatial` task 0, 10 trials | **10/10 (100%)** |
| LIBERO-plus | `libero_spatial` task 0, 5 trials | **5/5 (100%)** |

## Notes for reviewers

- The second commit (`setup_env.sh`) was already present uncommitted in the working tree on the machine used here. It is committed unmodified and kept separate from the documentation change, because rebuilding the libero-plus environment from the README depends on it. Please confirm it is intended before merging.
- The `--render-gpus 2,3` values in the example are illustrative for an 8-GPU host; the flag defaults to `--gpus`, so the previous behaviour is unchanged for anyone who does not pass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
