### PR TITLE
fix(video_backbone/wan): fall back to SDPA when flash-attn kernels cannot run

### DIFF
--- a/openwam/model/video_backbone/wan/models/dit.py
+++ b/openwam/model/video_backbone/wan/models/dit.py
@@ -39,7 +39,9 @@ def flash_attention(
     compatibility_mode=False,
     attn_mask: Optional[torch.Tensor] = None,
 ):
-    if compatibility_mode or attn_mask is not None:
+    # FA2/FA3/sage are CUDA half-precision kernels; they raise on anything else.
+    fused_ok = q.is_cuda and q.dtype in (torch.float16, torch.bfloat16)
+    if compatibility_mode or attn_mask is not None or not fused_ok:
         q = rearrange(q, "b s (n d) -> b n s d", n=num_heads)
         k = rearrange(k, "b s (n d) -> b n s d", n=num_heads)
         v = rearrange(v, "b s (n d) -> b n s d", n=num_heads)


### PR DESCRIPTION
Thanks for open-sourcing OpenWAM — the codebase has been a pleasure to work through.

While running the test suite on a GPU box I hit three failures that turned out to come from the attention backend selection rather than from the tests. Happy to adjust anything below if you'd prefer a different approach.

## What happens

`flash_attention()` in `openwam/model/video_backbone/wan/models/dit.py` chooses its backend purely from import availability:

```python
if compatibility_mode or attn_mask is not None:
    ...  # SDPA
elif FLASH_ATTN_3_AVAILABLE:
    x = flash_attn_interface.flash_attn_func(q, k, v)
elif FLASH_ATTN_2_AVAILABLE:
    x = flash_attn.flash_attn_func(q, k, v)
```

FA2/FA3/sage are CUDA-only, half-precision-only kernels, and they raise rather than degrade. So as soon as `flash-attn` is importable, this helper fails on any fp32 or CPU input:

| input | result on `main` |
|---|---|
| `cuda` / `bf16` | OK |
| `cuda` / `fp32` | `RuntimeError: FlashAttention only support fp16 and bf16 data type` |
| `cpu` / `fp32` | `NotImplementedError: Could not run 'flash_attn::_flash_attn_forward' with arguments from the 'CPU' backend` |

Because `flash-attn` is not a declared dependency and CI installs CPU-only torch, CI never sees this. But it does affect the merge gate that `CONTRIBUTING.md` asks for: `tests/test_split_attn_equivalence.py:122` and two cases in `tests/test_single_system_attention_mask.py` call this path on CPU tensors with no `gpu` marker, so `make all` fails on any machine where `flash-attn` happens to be installed — which is most training boxes.

## Reproducing

Python 3.10.20, `torch 2.7.1+cu128` per the README, `pip install -e '.[dev]'`, plus the official `flash_attn 2.8.3.post1` wheel for `cu12torch2.7cxx11abiTRUE-cp310`:

```
# on main
$ pytest -q tests/test_single_system_attention_mask.py tests/test_split_attn_equivalence.py
3 failed, 21 passed

# with this patch
$ pytest -q tests/test_single_system_attention_mask.py tests/test_split_attn_equivalence.py
24 passed
```

## The change

```python
fused_ok = q.is_cuda and q.dtype in (torch.float16, torch.bfloat16)
if compatibility_mode or attn_mask is not None or not fused_ok:
```

The folded condition is equivalent to the existing final `else` branch whenever `attn_mask is None`, so the fast path is untouched — I confirmed with a spy on `flash_attn_func` that it is still called for `cuda`/`bf16` and skipped only for the two cases that previously raised.

This mirrors what the ActionDiT path already does in `openwam/model/action_backbone/components.py:280-340`, which guards all four of its backends the same way:

```python
def _flash2(q, k, v):
    if q.device.type != "cuda":
        return _sdpa(q, k, v)
```

For reference, upstream `Wan-Video/Wan2.2` asserts the same two conditions in `wan/modules/attention.py:52-54` (`assert dtype in half_dtypes`, `assert q.device.type == 'cuda'`); falling back seemed friendlier here than asserting, since the CPU path is exercised by the test suite.

## Verification

Full suite in the environment above: **1956 passed, 20 skipped, 0 failed**. `ruff check openwam/ scripts/ tests/` and `compileall` both clean, so `make all` and `make check` pass.

## Two related spots I left alone

- `openwam/model/video_backbone/wan/shared/core/attention/attention.py:35-50` has the same unguarded selection, resolved once at import time. It sits under `wan/shared/`, which reads as vendored, so it seemed better to leave that to your judgement.
- `openwam/deploy/server.py:377-390` reports the DiT backend from the availability flags alone, so with this patch it can log `flash_attention_2` on a run that correctly uses SDPA. Cosmetic, and happy to fix it here or in a follow-up if useful.
