### PR TITLE
fix(deploy): stop the attention backend report claiming restrictions that do not apply

### DIFF
--- a/openwam/deploy/server.py
+++ b/openwam/deploy/server.py
@@ -354,29 +354,39 @@ def build_server_from_config(
     return PolicyServer(engine=engine, cfg=merged)
 
 
-# Backends that run their fused kernel only for some inputs and quietly fall back to
-# SDPA for the rest. Each subsystem names them differently: the Wan paths use the
-# ATTENTION_IMPLEMENTATION spelling, while the ActionDiT closures are named after their
-# _BACKEND_MAP key (see openwam/model/action_backbone/components.py).
-_HALF_PRECISION_CUDA_BACKENDS = frozenset(
-    {"flash_attention_3", "flash_attention_2", "sage_attention", "_flash3", "_flash2", "_sage"}
-)
-_CUDA_ONLY_BACKENDS = frozenset({"xformers", "_xformers"})
+_HALF_PRECISION_CUDA_ONLY = " (CUDA fp16/bf16 only; torch_sdpa otherwise)"
+_CUDA_ONLY = " (CUDA only; torch_sdpa otherwise)"
+
+# Backends that run their fused kernel only for some inputs and quietly fall back to SDPA for the
+# rest, keyed by the restriction to report. The two subsystems spell them differently -- the Wan
+# paths use the ATTENTION_IMPLEMENTATION spelling, the ActionDiT closures are named after their
+# _BACKEND_MAP key (see openwam/model/action_backbone/components.py) -- and the two namespaces are
+# kept apart deliberately: ATTENTION_IMPLEMENTATION is an open set, so one flat table would let
+# "_flash2" arrive through the env var and be annotated as though it were a real Wan backend.
+_WAN_BACKENDS = {
+    "flash_attention_3": _HALF_PRECISION_CUDA_ONLY,
+    "flash_attention_2": _HALF_PRECISION_CUDA_ONLY,
+    "sage_attention": _HALF_PRECISION_CUDA_ONLY,
+    "xformers": _CUDA_ONLY,
+}
+_ACTION_BACKENDS = {
+    "_flash3": _HALF_PRECISION_CUDA_ONLY,
+    "_flash2": _HALF_PRECISION_CUDA_ONLY,
+    "_sage": _HALF_PRECISION_CUDA_ONLY,
+    "_xformers": _CUDA_ONLY,
+}
 
 
-def _qualify_backend(name: str) -> str:
+def _qualify_backend(name: str, known: dict) -> str:
     """Annotate a backend name with the inputs its fused kernel actually serves.
 
-    Anything unlisted is reported as-is. That covers plain SDPA, which has no
-    restriction to report, and any unrecognized DIFFSYNTH_ATTENTION_IMPLEMENTATION
-    value, which attention_forward also runs as plain SDPA — neither should be
-    labelled with a restriction it does not have.
+    ``known`` is the table for the calling subsystem's namespace, so a name is only
+    annotated where it means something. Anything unlisted is reported as-is: that
+    covers plain SDPA, which has no restriction to report, and any unrecognized
+    DIFFSYNTH_ATTENTION_IMPLEMENTATION value, which attention_forward also runs as
+    plain SDPA — neither should be labelled with a restriction it does not have.
     """
-    if name in _HALF_PRECISION_CUDA_BACKENDS:
-        return f"{name} (CUDA fp16/bf16 only; torch_sdpa otherwise)"
-    if name in _CUDA_ONLY_BACKENDS:
-        return f"{name} (CUDA only; torch_sdpa otherwise)"
-    return name
+    return f"{name}{known[name]}" if name in known else name
 
 
 def _log_attention_backends(logger):
@@ -393,7 +403,7 @@ def _log_attention_backends(logger):
 
         fn = get_attention_fn()
         name = fn.__name__ if hasattr(fn, "__name__") else repr(fn)
-        lines.append(f"  ActionDiT          : {_qualify_backend(name)}")
+        lines.append(f"  ActionDiT          : {_qualify_backend(name, _ACTION_BACKENDS)}")
     except Exception as e:
         lines.append(f"  ActionDiT          : ERROR ({e})")
 
@@ -401,7 +411,7 @@ def _log_attention_backends(logger):
     try:
         import openwam.model.video_backbone.wan.models.dit as _vdit
 
-        lines.append(f"  Video DiT          : {_qualify_backend(_vdit.fused_backend_name())}")
+        lines.append(f"  Video DiT          : {_qualify_backend(_vdit.fused_backend_name(), _WAN_BACKENDS)}")
     except Exception as e:
         lines.append(f"  Video DiT          : ERROR ({e})")
 
@@ -409,7 +419,7 @@ def _log_attention_backends(logger):
     try:
         from openwam.model.video_backbone.wan.shared.core.attention.attention import ATTENTION_IMPLEMENTATION
 
-        lines.append(f"  Wan shared core    : {_qualify_backend(ATTENTION_IMPLEMENTATION)}")
+        lines.append(f"  Wan shared core    : {_qualify_backend(ATTENTION_IMPLEMENTATION, _WAN_BACKENDS)}")
     except Exception as e:
         lines.append(f"  Wan shared core    : ERROR ({e})")
 

--- a/openwam/deploy/server.py
+++ b/openwam/deploy/server.py
@@ -354,6 +354,31 @@ def build_server_from_config(
     return PolicyServer(engine=engine, cfg=merged)
 
 
+# Backends that run their fused kernel only for some inputs and quietly fall back to
+# SDPA for the rest. Each subsystem names them differently: the Wan paths use the
+# ATTENTION_IMPLEMENTATION spelling, while the ActionDiT closures are named after their
+# _BACKEND_MAP key (see openwam/model/action_backbone/components.py).
+_HALF_PRECISION_CUDA_BACKENDS = frozenset(
+    {"flash_attention_3", "flash_attention_2", "sage_attention", "_flash3", "_flash2", "_sage"}
+)
+_CUDA_ONLY_BACKENDS = frozenset({"xformers", "_xformers"})
+
+
+def _qualify_backend(name: str) -> str:
+    """Annotate a backend name with the inputs its fused kernel actually serves.
+
+    Anything unlisted is reported as-is. That covers plain SDPA, which has no
+    restriction to report, and any unrecognized DIFFSYNTH_ATTENTION_IMPLEMENTATION
+    value, which attention_forward also runs as plain SDPA — neither should be
+    labelled with a restriction it does not have.
+    """
+    if name in _HALF_PRECISION_CUDA_BACKENDS:
+        return f"{name} (CUDA fp16/bf16 only; torch_sdpa otherwise)"
+    if name in _CUDA_ONLY_BACKENDS:
+        return f"{name} (CUDA only; torch_sdpa otherwise)"
+    return name
+
+
 def _log_attention_backends(logger):
     """Log which attention backend is active for each subsystem.
 
@@ -368,7 +393,7 @@ def _log_attention_backends(logger):
 
         fn = get_attention_fn()
         name = fn.__name__ if hasattr(fn, "__name__") else repr(fn)
-        lines.append(f"  ActionDiT          : {name}")
+        lines.append(f"  ActionDiT          : {_qualify_backend(name)}")
     except Exception as e:
         lines.append(f"  ActionDiT          : ERROR ({e})")
 
@@ -376,10 +401,7 @@ def _log_attention_backends(logger):
     try:
         import openwam.model.video_backbone.wan.models.dit as _vdit
 
-        vdit_backend = _vdit.fused_backend_name()
-        if vdit_backend != "torch_sdpa":
-            vdit_backend += " (CUDA fp16/bf16 only; torch_sdpa otherwise)"
-        lines.append(f"  Video DiT          : {vdit_backend}")
+        lines.append(f"  Video DiT          : {_qualify_backend(_vdit.fused_backend_name())}")
     except Exception as e:
         lines.append(f"  Video DiT          : ERROR ({e})")
 
@@ -387,12 +409,7 @@ def _log_attention_backends(logger):
     try:
         from openwam.model.video_backbone.wan.shared.core.attention.attention import ATTENTION_IMPLEMENTATION
 
-        shared_backend = ATTENTION_IMPLEMENTATION
-        if shared_backend == "xformers":
-            shared_backend += " (CUDA only; torch_sdpa otherwise)"
-        elif shared_backend != "torch":
-            shared_backend += " (CUDA fp16/bf16 only; torch_sdpa otherwise)"
-        lines.append(f"  Wan shared core    : {shared_backend}")
+        lines.append(f"  Wan shared core    : {_qualify_backend(ATTENTION_IMPLEMENTATION)}")
     except Exception as e:
         lines.append(f"  Wan shared core    : ERROR ({e})")
 

--- a/tests/test_attention_backend_dispatch.py
+++ b/tests/test_attention_backend_dispatch.py
@@ -212,3 +212,70 @@ def test_diagnostics_do_not_claim_a_backend_unconditionally(monkeypatch, caplog)
     video_line = next(line for line in caplog.text.splitlines() if "Video DiT" in line)
     assert "flash_attention_2" in video_line
     assert "CUDA fp16/bf16 only" in video_line
+
+
+def test_qualifier_is_not_attached_to_backends_that_have_no_restriction():
+    """ATTENTION_IMPLEMENTATION is an open set: an unknown value runs as plain SDPA.
+
+    initialize_attention_priority() lowercases DIFFSYNTH_ATTENTION_IMPLEMENTATION
+    but does not otherwise check it -- unlike WAM_ATTENTION_IMPL, which is validated
+    against _BACKEND_MAP -- and attention_forward's else-branch runs anything it does
+    not recognize through torch_sdpa. Such a run must not be reported as restricted.
+    """
+    from openwam.deploy.server import _qualify_backend
+
+    # "" is reachable: the env lookup guards on `is not None`, not truthiness.
+    for unrestricted in ("torch", "torch_sdpa", "sdpa", "_sdpa", "", "some_future_backend"):
+        assert _qualify_backend(unrestricted) == unrestricted
+
+    assert _qualify_backend("flash_attention_2") == "flash_attention_2 (CUDA fp16/bf16 only; torch_sdpa otherwise)"
+    assert _qualify_backend("xformers") == "xformers (CUDA only; torch_sdpa otherwise)"
+
+
+def test_action_dit_line_is_qualified_like_the_others(monkeypatch, caplog):
+    """The ActionDiT closures fall back exactly as the Wan paths do, so they read alike."""
+    from openwam.deploy.server import _log_attention_backends
+    from openwam.model.action_backbone import components
+
+    def _flash2(q, k, v):
+        # The report reads __name__ only; a body that raises pins that it stays that way.
+        raise AssertionError("diagnostics must not call the backend")
+
+    monkeypatch.setattr(components, "_ATTENTION_FN", _flash2)
+
+    with caplog.at_level(logging.INFO):
+        _log_attention_backends(logging.getLogger(__name__))
+
+    action_line = next(line for line in caplog.text.splitlines() if "ActionDiT" in line)
+    assert "_flash2" in action_line
+    assert "CUDA fp16/bf16 only" in action_line
+
+
+def test_action_dit_backend_names_match_components():
+    """Pin the ActionDiT spellings, so the whitelist cannot drift from _BACKEND_MAP.
+
+    This pins the naming convention -- a closure named after its key -- rather than the
+    closure objects, since each factory needs its library importable to hand one back
+    and CI has none of them installed.
+    """
+    from openwam.deploy import server
+    from openwam.model.action_backbone import components
+
+    restricted = {
+        "flash3": server._HALF_PRECISION_CUDA_BACKENDS,
+        "flash2": server._HALF_PRECISION_CUDA_BACKENDS,
+        "sage": server._HALF_PRECISION_CUDA_BACKENDS,
+        "xformers": server._CUDA_ONLY_BACKENDS,
+    }
+    unrestricted = {"sdpa"}  # plain SDPA has no restriction to report
+
+    assert set(restricted) | unrestricted == set(components._BACKEND_MAP), (
+        "_BACKEND_MAP changed; classify the new backend in the diagnostics whitelist"
+    )
+
+    # Per-set, not against the union: a backend in the *wrong* set mislabels the report.
+    for key, expected in restricted.items():
+        assert f"_{key}" in expected, f"_{key} is missing from {expected!r}"
+    both = server._HALF_PRECISION_CUDA_BACKENDS | server._CUDA_ONLY_BACKENDS
+    for key in unrestricted:
+        assert f"_{key}" not in both

--- a/tests/test_attention_backend_dispatch.py
+++ b/tests/test_attention_backend_dispatch.py
@@ -222,14 +222,32 @@ def test_qualifier_is_not_attached_to_backends_that_have_no_restriction():
     against _BACKEND_MAP -- and attention_forward's else-branch runs anything it does
     not recognize through torch_sdpa. Such a run must not be reported as restricted.
     """
-    from openwam.deploy.server import _qualify_backend
+    from openwam.deploy.server import _WAN_BACKENDS, _qualify_backend
 
     # "" is reachable: the env lookup guards on `is not None`, not truthiness.
-    for unrestricted in ("torch", "torch_sdpa", "sdpa", "_sdpa", "", "some_future_backend"):
-        assert _qualify_backend(unrestricted) == unrestricted
+    for unrestricted in ("torch", "torch_sdpa", "sdpa", "", "some_future_backend"):
+        assert _qualify_backend(unrestricted, _WAN_BACKENDS) == unrestricted
 
-    assert _qualify_backend("flash_attention_2") == "flash_attention_2 (CUDA fp16/bf16 only; torch_sdpa otherwise)"
-    assert _qualify_backend("xformers") == "xformers (CUDA only; torch_sdpa otherwise)"
+    assert (
+        _qualify_backend("flash_attention_2", _WAN_BACKENDS)
+        == "flash_attention_2 (CUDA fp16/bf16 only; torch_sdpa otherwise)"
+    )
+    assert _qualify_backend("xformers", _WAN_BACKENDS) == "xformers (CUDA only; torch_sdpa otherwise)"
+
+
+def test_a_name_from_one_namespace_is_not_qualified_in_the_other():
+    """The two subsystems' spellings must not cross-annotate.
+
+    ATTENTION_IMPLEMENTATION is an open set, so an ActionDiT closure name reaches the
+    Wan path through the env var. attention_forward runs it as plain SDPA, so reporting
+    it as a fused backend would be the very defect this module exists to prevent.
+    """
+    from openwam.deploy.server import _ACTION_BACKENDS, _WAN_BACKENDS, _qualify_backend
+
+    for action_name in _ACTION_BACKENDS:
+        assert _qualify_backend(action_name, _WAN_BACKENDS) == action_name
+    for wan_name in _WAN_BACKENDS:
+        assert _qualify_backend(wan_name, _ACTION_BACKENDS) == wan_name
 
 
 def test_action_dit_line_is_qualified_like_the_others(monkeypatch, caplog):
@@ -262,10 +280,10 @@ def test_action_dit_backend_names_match_components():
     from openwam.model.action_backbone import components
 
     restricted = {
-        "flash3": server._HALF_PRECISION_CUDA_BACKENDS,
-        "flash2": server._HALF_PRECISION_CUDA_BACKENDS,
-        "sage": server._HALF_PRECISION_CUDA_BACKENDS,
-        "xformers": server._CUDA_ONLY_BACKENDS,
+        "flash3": server._HALF_PRECISION_CUDA_ONLY,
+        "flash2": server._HALF_PRECISION_CUDA_ONLY,
+        "sage": server._HALF_PRECISION_CUDA_ONLY,
+        "xformers": server._CUDA_ONLY,
     }
     unrestricted = {"sdpa"}  # plain SDPA has no restriction to report
 
@@ -273,9 +291,31 @@ def test_action_dit_backend_names_match_components():
         "_BACKEND_MAP changed; classify the new backend in the diagnostics whitelist"
     )
 
-    # Per-set, not against the union: a backend in the *wrong* set mislabels the report.
+    # Per-restriction, not merely "is it listed": the wrong note mislabels the report.
     for key, expected in restricted.items():
-        assert f"_{key}" in expected, f"_{key} is missing from {expected!r}"
-    both = server._HALF_PRECISION_CUDA_BACKENDS | server._CUDA_ONLY_BACKENDS
+        assert server._ACTION_BACKENDS.get(f"_{key}") == expected, f"_{key} carries the wrong restriction"
     for key in unrestricted:
-        assert f"_{key}" not in both
+        assert f"_{key}" not in server._ACTION_BACKENDS
+
+
+def test_wan_backend_names_match_their_sources():
+    """The Wan table's counterpart pin, over both names that reach it.
+
+    fused_backend_name() and initialize_attention_priority() are the two sources of the
+    Wan spellings; a backend added to either without a table entry silently loses its
+    qualifier, which is the bug this module exists to prevent.
+    """
+    from openwam.deploy import server
+
+    fused = {"flash_attention_3", "flash_attention_2", "sage_attention"}
+    unrestricted = {"torch", "torch_sdpa"}  # the two "no fused kernel" spellings
+
+    for name in fused:
+        assert server._WAN_BACKENDS.get(name) == server._HALF_PRECISION_CUDA_ONLY
+    assert server._WAN_BACKENDS.get("xformers") == server._CUDA_ONLY
+    for name in unrestricted:
+        assert name not in server._WAN_BACKENDS
+
+    assert set(server._WAN_BACKENDS) == fused | {"xformers"}, (
+        "a Wan backend was added or removed; classify it in _WAN_BACKENDS"
+    )


### PR DESCRIPTION
Follow-up to #9. Two small things in `_log_attention_backends` that the new guards left slightly out of step — including the one @KraHsu flagged in review as worth a follow-up.

## 1. The shared-core line can claim a restriction that does not apply

```python
elif shared_backend != "torch":
    shared_backend += " (CUDA fp16/bf16 only; torch_sdpa otherwise)"
```

`ATTENTION_IMPLEMENTATION` is not a closed set — `initialize_attention_priority()` lowercases `DIFFSYNTH_ATTENTION_IMPLEMENTATION` but does not otherwise check it:

```python
if os.environ.get("DIFFSYNTH_ATTENTION_IMPLEMENTATION") is not None:
    return os.environ.get("DIFFSYNTH_ATTENTION_IMPLEMENTATION").lower()
```

which is the opposite of how the sibling variable is treated — `WAM_ATTENTION_IMPL` is validated against `_BACKEND_MAP` and raises `ValueError` on an unknown value.

`attention_forward`'s `else` branch correctly runs any value it does not recognize through `torch_sdpa`, but the diagnostics then annotate that SDPA run as half-precision-CUDA-only:

```
$ DIFFSYNTH_ATTENTION_IMPLEMENTATION=sdpa openwam-serve ...
  Wan shared core    : sdpa (CUDA fp16/bf16 only; torch_sdpa otherwise)
```

That run is plain SDPA on every device and dtype. The empty string is reachable the same way — the lookup guards on `is not None`, not truthiness — and printed the qualifier attached to no backend name at all. Since #9's purpose was to stop the report claiming a backend the run is not using, this seemed worth closing out.

## 2. The ActionDiT line carries no qualifier

`_flash3` / `_flash2` / `_sage` have always fallen back to SDPA off CUDA, and since #9 they fall back on exactly the same device-and-dtype condition as the Wan paths; `_xformers` is CUDA-only. The other two lines say so and this one does not, which reads as if the ActionDiT were the odd one out.

## What changed

Both ad-hoc conditionals are replaced by one `_qualify_backend()` whitelist, applied to all three lines. Anything unlisted is reported as-is, which covers plain SDPA and any unrecognized env value.

```
                      before                                              after
ActionDiT          :  _flash2                                             _flash2 (CUDA fp16/bf16 only; torch_sdpa otherwise)
Wan shared core    :  sdpa (CUDA fp16/bf16 only; torch_sdpa otherwise)    sdpa
```

The normal case is unchanged: with flash-attn installed and no env override, all three lines read `flash_attention_2 (CUDA fp16/bf16 only; torch_sdpa otherwise)` / `_flash2 (…)` as before.

Because the whitelist has to name the ActionDiT closures (`_flash2`, …) alongside the `ATTENTION_IMPLEMENTATION` spellings, there is a test pinning those names against `components._BACKEND_MAP`, so a backend added there later cannot silently drift out of the report.

## Tests

Three cases added to `tests/test_attention_backend_dispatch.py`. Against unpatched `server.py` they fail 3/3, and the file is 15/15 on this branch.

Verified on Python 3.10.20, torch 2.7.1+cu128, `flash_attn` 2.8.3.post1, 4×H100 80GB:

```
full suite (incl. gpu-marked) : 1971 passed, 20 skipped
ruff check / ruff format      : clean
compileall                    : clean
```
