### PR TITLE
fix(attention): validate DIFFSYNTH_ATTENTION_IMPLEMENTATION before using it

### DIFF
--- a/openwam/model/video_backbone/wan/shared/core/attention/attention.py
+++ b/openwam/model/video_backbone/wan/shared/core/attention/attention.py
@@ -1,7 +1,10 @@
+import logging
 import os
 
 import torch
 from einops import rearrange
+
+logger = logging.getLogger(__name__)
 
 try:
     import flash_attn_interface
@@ -32,19 +35,48 @@ except ModuleNotFoundError:
     XFORMERS_AVAILABLE = False
 
 
+def _available_implementations() -> dict:
+    """The implementation names this build can actually dispatch, in priority order."""
+    return {
+        "flash_attention_3": FLASH_ATTN_3_AVAILABLE,
+        "flash_attention_2": FLASH_ATTN_2_AVAILABLE,
+        "sage_attention": SAGE_ATTN_AVAILABLE,
+        "xformers": XFORMERS_AVAILABLE,
+        "torch": True,
+    }
+
+
 def initialize_attention_priority():
-    if os.environ.get("DIFFSYNTH_ATTENTION_IMPLEMENTATION") is not None:
-        return os.environ.get("DIFFSYNTH_ATTENTION_IMPLEMENTATION").lower()
-    elif FLASH_ATTN_3_AVAILABLE:
+    """Resolve the attention implementation, honouring an explicit env override.
+
+    An override is validated the way WAM_ATTENTION_IMPL is in
+    openwam/model/action_backbone/components.py: an unknown name raises, and a known
+    name whose library did not import warns and falls back to auto-detection rather
+    than failing later inside the kernel wrapper.
+    """
+    # An empty or whitespace-only value reads as "no override", matching the sibling.
+    override = os.environ.get("DIFFSYNTH_ATTENTION_IMPLEMENTATION", "").strip().lower()
+    if override:
+        available = _available_implementations()
+        if override not in available:
+            raise ValueError(
+                f"Unknown DIFFSYNTH_ATTENTION_IMPLEMENTATION='{override}'. Choose from: {sorted(available)}"
+            )
+        if available[override]:
+            return override
+        logger.warning(
+            "DIFFSYNTH_ATTENTION_IMPLEMENTATION='%s' requested but not available, falling back to auto-detect",
+            override,
+        )
+    if FLASH_ATTN_3_AVAILABLE:
         return "flash_attention_3"
-    elif FLASH_ATTN_2_AVAILABLE:
+    if FLASH_ATTN_2_AVAILABLE:
         return "flash_attention_2"
-    elif SAGE_ATTN_AVAILABLE:
+    if SAGE_ATTN_AVAILABLE:
         return "sage_attention"
-    elif XFORMERS_AVAILABLE:
+    if XFORMERS_AVAILABLE:
         return "xformers"
-    else:
-        return "torch"
+    return "torch"
 
 
 ATTENTION_IMPLEMENTATION = initialize_attention_priority()

--- a/tests/test_attention_env_override.py
+++ b/tests/test_attention_env_override.py
@@ -1,0 +1,115 @@
+"""Regression tests for the DIFFSYNTH_ATTENTION_IMPLEMENTATION override.
+
+The override used to be taken verbatim, so a name whose library never imported
+was returned anyway and failed later inside the kernel wrapper with a NameError.
+These pin the contract against its sibling WAM_ATTENTION_IMPL in
+``openwam/model/action_backbone/components.py``: unknown name raises, known but
+unavailable warns and falls back, known and available is honoured.
+
+The availability flags are faked, so every case runs on CPU-only CI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+ENV = "DIFFSYNTH_ATTENTION_IMPLEMENTATION"
+FLAGS = {
+    "flash_attention_3": "FLASH_ATTN_3_AVAILABLE",
+    "flash_attention_2": "FLASH_ATTN_2_AVAILABLE",
+    "sage_attention": "SAGE_ATTN_AVAILABLE",
+    "xformers": "XFORMERS_AVAILABLE",
+}
+
+
+def _shared():
+    from openwam.model.video_backbone.wan.shared.core.attention import attention as shared
+
+    return shared
+
+
+def _set_availability(monkeypatch, available: set):
+    """Fake which libraries imported, so these run without any of them installed."""
+    shared = _shared()
+    for name, flag in FLAGS.items():
+        monkeypatch.setattr(shared, flag, name in available)
+    return shared
+
+
+def test_unknown_override_raises_and_names_the_choices(monkeypatch):
+    shared = _set_availability(monkeypatch, set(FLAGS))
+    monkeypatch.setenv(ENV, "bogus_backend")
+
+    with pytest.raises(ValueError) as excinfo:
+        shared.initialize_attention_priority()
+
+    message = str(excinfo.value)
+    assert "bogus_backend" in message
+    # the message must be actionable, not just a rejection
+    for name in FLAGS:
+        assert name in message
+
+
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_blank_override_reads_as_no_override(monkeypatch, blank):
+    """`DIFFSYNTH_ATTENTION_IMPLEMENTATION=` is reachable and must not be an error.
+
+    WAM_ATTENTION_IMPL does `.strip().lower()` then `if override:`, so a blank value
+    falls through to auto-detection there. An accidental `export VAR=` must not turn
+    into a hard failure at import.
+    """
+    shared = _set_availability(monkeypatch, {"sage_attention"})
+    monkeypatch.setenv(ENV, blank)
+
+    assert shared.initialize_attention_priority() == "sage_attention"
+
+
+def test_unavailable_override_warns_and_falls_back(monkeypatch, caplog):
+    """The case that used to NameError inside the kernel wrapper."""
+    shared = _set_availability(monkeypatch, {"flash_attention_2"})
+    monkeypatch.setenv(ENV, "flash_attention_3")
+
+    with caplog.at_level(logging.WARNING):
+        resolved = shared.initialize_attention_priority()
+
+    assert resolved == "flash_attention_2", "should fall back to auto-detect, not honour the request"
+    assert "flash_attention_3" in caplog.text
+    assert "not available" in caplog.text
+
+
+def test_available_override_is_honoured(monkeypatch):
+    shared = _set_availability(monkeypatch, {"flash_attention_2", "sage_attention"})
+    monkeypatch.setenv(ENV, "sage_attention")
+
+    assert shared.initialize_attention_priority() == "sage_attention"
+
+
+def test_override_is_normalized(monkeypatch):
+    """Match the sibling, which does .strip().lower() before its membership check."""
+    shared = _set_availability(monkeypatch, {"flash_attention_2"})
+    monkeypatch.setenv(ENV, "  FLASH_ATTENTION_2  ")
+
+    assert shared.initialize_attention_priority() == "flash_attention_2"
+
+
+def test_torch_is_always_selectable(monkeypatch):
+    """Plain SDPA needs no library, so it must be honoured even with nothing installed."""
+    shared = _set_availability(monkeypatch, set())
+    monkeypatch.setenv(ENV, "torch")
+
+    assert shared.initialize_attention_priority() == "torch"
+
+
+def test_without_override_auto_detection_is_unchanged(monkeypatch):
+    shared = _set_availability(monkeypatch, {"flash_attention_2", "sage_attention", "xformers"})
+    monkeypatch.delenv(ENV, raising=False)
+
+    assert shared.initialize_attention_priority() == "flash_attention_2"
+
+    shared = _set_availability(monkeypatch, {"xformers"})
+    assert shared.initialize_attention_priority() == "xformers"
+
+    shared = _set_availability(monkeypatch, set())
+    assert shared.initialize_attention_priority() == "torch"


### PR DESCRIPTION
Resolves #12.

I asked in that issue which semantics you wanted and then realised I'd handed back a decision I could make: the strongest argument is repo-internal consistency, and `get_attention_fn` in `openwam/model/action_backbone/components.py` already answers every case. So this mirrors the sibling rather than inventing a policy — if you disagree with any case, it's one function to adjust.

## What it does

`initialize_attention_priority` now matches `WAM_ATTENTION_IMPL` case for case:

| override | before | after |
|---|---|---|
| `flash_attention_3`, FA3 not installed | selected, then `NameError` inside the kernel wrapper | warns, falls back to auto-detect |
| `bogus` | accepted, silently ran SDPA | `ValueError` listing the valid names |
| `` (empty) or whitespace | accepted, ran SDPA, logged a blank backend name | reads as no override → auto-detect |
| `  FLASH_ATTENTION_2  ` | not normalized | `.strip().lower()`, honoured |
| unset | auto-detect | unchanged |

The `NameError` is the one I'd call a plain bug, verified on Python 3.10.20, torch 2.7.1+cu128, `flash_attn` 2.8.3.post1, 4×H100:

```
$ DIFFSYNTH_ATTENTION_IMPLEMENTATION=flash_attention_3     # before
resolve_implementation -> flash_attention_3
attention_forward: NameError: name 'flash_attn_interface' is not defined

$ DIFFSYNTH_ATTENTION_IMPLEMENTATION=flash_attention_3     # after
WARN: DIFFSYNTH_ATTENTION_IMPLEMENTATION='flash_attention_3' requested but not available, falling back to auto-detect
resolved='flash_attention_2'  forward=(1, 2, 8, 16)
```

## On the blank case, since it's the one that could bite

My first draft raised on an empty value, on the reasoning that it's reachable and meaningless. That was wrong, and I caught it before pushing: the sibling does `os.environ.get(..., "").strip().lower()` then `if override:`, so blank falls through to auto-detection there. Raising would have turned a stray `export DIFFSYNTH_ATTENTION_IMPLEMENTATION=` in someone's launch script into a hard failure at import — a real regression for no benefit. It now reads as no override, and `test_blank_override_reads_as_no_override` pins that for `""` and `"   "`.

That is also why I did **not** take @wayrise's `torch_sdpa (unrecognized: "")` suggestion from #11: with blank resolving to a real auto-detected backend, there is no blank name left for the report to render.

## Tests

`tests/test_attention_env_override.py`, 8 cases, in its own file so it does not collide with #11's changes to `test_attention_backend_dispatch.py`. The availability flags are faked, so every case runs on CPU-only CI with none of the libraries installed — which is the configuration where this bug is invisible.

Against unpatched `attention.py` the shipped file fails 5/8; the 3 that pass either way are the already-correct behaviours, kept so a future change can't over-correct.

```
full suite      : 1976 passed, 20 skipped
ruff check      : clean
ruff format     : clean
compileall      : clean
```

## Note on ordering

This branches from `main`, not from #11, and touches disjoint files (`attention.py` + a new test file, versus `deploy/server.py` + `test_attention_backend_dispatch.py`), so the two merge in either order without conflict.
