### PR TITLE
fix(tests): repair the joint_cross_attn real-Cosmos GPU test

### DIFF
--- a/tests/test_cosmos_predict25_joint_cross_attn.py
+++ b/tests/test_cosmos_predict25_joint_cross_attn.py
@@ -176,7 +176,7 @@ def test_video_only_path_matches_full_forward_video():
 
 
 @pytest.mark.gpu
-def test_joint_cross_attn_forward_on_real_cosmos():
+def test_joint_cross_attn_forward_on_real_cosmos(stub_reason1):
     """joint_cross_attn + real Cosmos-Predict2.5-2B: one forward restores 5D
     video, yields a finite action prediction, and preserves the cross-attn
     isolation invariant (video independent of the action input)."""
@@ -205,7 +205,7 @@ def test_joint_cross_attn_forward_on_real_cosmos():
             overrides=[
                 "model=dual_system",
                 "model.architecture.variant=joint_cross_attn",
-                "model/video_backbone=cosmos_predict25",
+                "model/video_backbone=cosmos_predict25_2b",
                 f"model.video_backbone.model_path={COSMOS25_2B}",
             ],
         )


### PR DESCRIPTION
`test_joint_cross_attn_forward_on_real_cosmos` has not actually run since commit `4d8df56` ("Document OpenWAM usage and unify component keys"), which replaced `configs/model/video_backbone/cosmos_predict25.yaml` with `cosmos_predict25_2b.yaml`. The test's Hydra override was missed, so it raised `MissingConfigException` before any model code ran:

```
$ pytest tests/test_cosmos_predict25_joint_cross_attn.py
hydra.errors.MissingConfigException: In 'model/video_backbone': Could not find 'model/video_backbone/cosmos_predict25'
```

It is the only stale reference left — `assets/openwam_usage_docs/train-and-deploy.md` and the `openwam-serve --help` text already use `cosmos_predict25_2b`, and `model_loader.py` gates on the `cosmos_predict25_` prefix.

The failure is invisible without the Cosmos-Predict2.5-2B checkpoint mounted, so CI skips it and it only surfaces on a box that has the weights — which is how it went unnoticed.

## Two lines

**1. The config name.** `model/video_backbone=cosmos_predict25` → `cosmos_predict25_2b`.

**2. The `stub_reason1` fixture.** With Hydra resolving, the test then hit `FileNotFoundError` from the live Reason1 text encoder, against the config's `/path/to/Cosmos-Reason1-7B` placeholder. This was the one real-Cosmos GPU test not requesting `stub_reason1`, the fixture that exists precisely so these tests skip the 16 GB Qwen load — its closest sibling `test_tri_system_forward_on_real_cosmos` uses it. The test never needed a real encoder anyway: it passes `context` to `forward()` directly.

## Verification

Run against real Cosmos-Predict2.5-2B weights on an H200 (`OPENWAM_COSMOS25_2B` pointed at the checkpoint):

```
tests/test_cosmos_predict25_joint_cross_attn.py   5 passed in 47s
```

The GPU case now genuinely loads the DiT and exercises the forward, rather than erroring or skipping. Full suite with the checkpoint visible:

```
1981 passed, 12 skipped
```

versus `1 failed, ... 20 skipped` before — the 8 fewer skips are the Cosmos GPU tests the checkpoint unlocks. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
