### PR TITLE
fix(robodojo): decode JPEG frames with the recorder's channel order

### DIFF
--- a/openwam/dataloader/robodojo.py
+++ b/openwam/dataloader/robodojo.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import bisect
 import hashlib
-import io
 import json
 import os
 import time
@@ -30,6 +29,7 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+import cv2
 import h5py
 import numpy as np
 import torch
@@ -357,14 +357,28 @@ def _jpeg_bytes(value: Any) -> bytes:
 
 
 def _decode_jpeg(value: Any, *, source: str) -> Image.Image:
+    """Decode JPEG bytes from HDF5 to a PIL RGB image.
+
+    RoboDojo encodes frames by passing RGB arrays directly to ``cv2.imencode``
+    (which expects BGR), so R and B channels are swapped inside the JPEG. Using
+    ``cv2.imdecode`` reverses this swap, giving back the original RGB order — no
+    further conversion needed. This is the same convention ``robotwin.py``
+    documents for the RoboTwin corpus.
+
+    Decoding with PIL instead returns the stored order, i.e. R and B swapped,
+    which is what this reader did until this was caught: the model trained on
+    channel-swapped frames while the deploy path (which decodes whatever the
+    eval client encodes, and every in-repo client encodes true RGB) served
+    correct ones. Confirmed against the corpora's own ``preview_video/*.mp4``,
+    which match this decoder and not PIL's, on both the sim and real corpora.
+    """
     encoded = _jpeg_bytes(value)
     if not encoded:
         raise ValueError(f"{source}: JPEG entry is empty")
-    try:
-        with Image.open(io.BytesIO(encoded)) as image:
-            return image.convert("RGB").copy()
-    except Exception as error:
-        raise ValueError(f"{source}: could not decode JPEG") from error
+    array = cv2.imdecode(np.frombuffer(encoded, np.uint8), cv2.IMREAD_COLOR)
+    if array is None:
+        raise ValueError(f"{source}: could not decode JPEG")
+    return Image.fromarray(array)
 
 
 def discover_robodojo_tasks(

--- a/tests/test_robodojo_dataloader.py
+++ b/tests/test_robodojo_dataloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
+import cv2
 import h5py
 import numpy as np
 import pytest
@@ -59,10 +60,18 @@ def write_calibration(root: Path) -> Path:
 
 
 def encode_jpeg(color: tuple[int, int, int], height: int = 18, width: int = 20) -> bytes:
-    image = Image.new("RGB", (width, height), color)
-    buffer = io.BytesIO()
-    image.save(buffer, format="JPEG", quality=100, subsampling=0)
-    return buffer.getvalue()
+    """Encode ``color`` (RGB) the way the RoboDojo recorder does.
+
+    It hands an RGB array straight to ``cv2.imencode``, which expects BGR, so R
+    and B end up swapped inside the file. Fixtures have to reproduce that or the
+    reader's ``cv2.imdecode`` — which exists to undo it — looks wrong under test
+    while being right on real data.
+    """
+    rgb = np.zeros((height, width, 3), dtype=np.uint8)
+    rgb[:, :] = color
+    ok, buffer = cv2.imencode(".jpg", rgb, [int(cv2.IMWRITE_JPEG_QUALITY), 100])
+    assert ok, "cv2.imencode failed"
+    return buffer.tobytes()
 
 
 def source_arrays(T: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
@@ -856,3 +865,25 @@ def test_registry_constructs_robodojo_and_exports_classes(tmp_path: Path):
     assert isinstance(dataset, MultiTaskRoboDojoDataset)
     assert isinstance(dataset._sub_datasets[0], RoboDojoDataset)
     assert dataset[0]["action"].shape == (2, 80)
+
+
+def test_decode_jpeg_undoes_the_recorder_channel_swap():
+    """The reader must return true RGB, not the stored order.
+
+    RoboDojo writes its JPEGs with ``cv2.imencode`` fed an RGB array, so the file
+    holds R and B swapped. Decoding with PIL returns that stored order and feeds
+    the model channel-swapped frames, which is what this reader did until it was
+    caught against the corpora's own preview videos. Pinned here because CI never
+    sees a real episode.
+    """
+    from openwam.dataloader.robodojo import _decode_jpeg
+
+    red = (230, 20, 15)
+    frame = np.asarray(_decode_jpeg(encode_jpeg(red), source="test"))
+
+    assert frame[0, 0, 0] > 200, "red must come back in channel 0"
+    assert frame[0, 0, 2] < 60, "blue must not have been swapped into channel 0"
+
+    # And the PIL reading of the very same bytes is the swap this guards against.
+    stored = np.asarray(Image.open(io.BytesIO(encode_jpeg(red))).convert("RGB"))
+    assert stored[0, 0, 2] > 200 and stored[0, 0, 0] < 60


### PR DESCRIPTION
Closes #13. Thanks @rakhimovv — you called this correctly from the asymmetry alone, without the data to confirm it.

I had RoboDojo trajectories on hand, so I settled the question you left open, then fixed it.

## It is the `cv2.imencode` case

Your "if" holds. Each corpus ships `preview_video/*.mp4` next to `data/`, produced by the recorder itself for humans to look at, on a path independent of both candidate decodings. Over saturated pixels (neutral areas are invariant under an R/B swap and just dilute the numbers), the preview matches `cv2.imdecode` and inverts PIL's — on **both** the sim and the real corpora, every episode checked:

```
real corpus, 10 episodes   mean |preview - cv2| =  7.57    mean |preview - PIL| = 45.34
sim corpus,  4 samples     mean |preview - cv2| =  1.7     mean |preview - PIL| = 40..57
```

The sim corpus makes it unarguable by eye: the scene is a rendered **wooden** desk with yellow number tiles, and PIL's reading makes the wood grain blue and the tiles cyan.

This is not circular — had the preview been made by decoding these JPEGs with cv2 and writing them straight out, it would match PIL instead. It does not, which means the recorder held true RGB, converted correctly for the video, and skipped the conversion for `cv2.imencode`. Exactly what `robotwin.py` describes.

## The fix

`_decode_jpeg` now uses `cv2.imdecode`, with `robotwin.py`'s rationale carried over. After it:

```
sim  corpus, production config   |preview - reader|  40..57  ->  3..16   (spread is the configured colour jitter)
real corpus, no jitter           |preview - reader|  31.74   ->   4.92   (= the JPEG vs H.264 floor)
```

Per-channel means went from transposed to aligned.

## Why the tests did not catch it

The fixture encoded with `PIL.Image.save(format="JPEG")` — the opposite convention to the recorder — so a wrong decoder round-tripped cleanly. It now encodes the way RoboDojo does, which makes the existing three-camera assertions (`head` R-dominant, `left_wrist` G, `right_wrist` B) pin the real contract instead of a fictional one, and a new test states the property outright. Reverting the decoder to PIL fails 4 tests.

## Scope

I walked the whole path rather than assuming, in both directions:

- **Training** — injecting a channel swap at `_decode_jpeg` flips the dataloader's output exactly, in both single-view and multiview mode, so nothing between the decode and the model touches channel order. `crop_and_resize`, `assemble_multiview_layout` and `VideoColorJitter` are all channel-agnostic.
- **Deploy** — `obs_preprocess` PIL-decodes the client's bytes and applies the same geometry helpers; feeding it these raw HDF5 bytes reproduces the PIL reading byte for byte. It performs no conversion, so eval colour is whatever the client encodes, and every in-repo client (`benchmarks/utils/client.py`, `mock_genmanip_server.py`) encodes true RGB. That is the train/eval mismatch you described.

RoboDojo's own eval client lives in XPolicyLab, so I could not verify that half from here; if it also sends true RGB, XPolicyLab/XPolicyLab#116 is this same bug seen downstream and should resolve with this.

```
full suite : 1982 passed, 20 skipped
ruff check / ruff format --check : clean
```

**Heads-up for anyone holding RoboDojo checkpoints:** this changes the training input distribution. Weights trained before it were fitted on channel-swapped frames and will not transfer cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
