### PR TITLE
docs: add arXiv paper release to README news

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ All architectures are selected via `configs/model/<framework>.yaml` with `archit
 -->
 
 ## News
+- **[2026/09/09]** 📄 OpenWAM [Paper](https://arxiv.org/pdf/2609.07398) is released on arXiv.
 - **[2026/09/06]** 🤖 OpenWAM is integrated into [XPolicyLab](https://github.com/XPolicyLab/XPolicyLab).
 - **[2026/09/06]** 🤗 We release all pretrained and finetuned models on [huggingface](https://huggingface.co/OpenWAM).
 - **[2026/09/06]** 🔥 OpenWAM Codebase Release！


### PR DESCRIPTION
Adds a News entry for the arXiv release of the OpenWAM paper.

```markdown
- **[2026/09/09]** 📄 OpenWAM [Paper](https://arxiv.org/pdf/2609.07398) is released on arXiv.
```

Complements #18, which added the arXiv badge and the BibTeX citation but left the News section untouched. Follows the existing entry format and keeps the list in reverse-chronological order. Link verified (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
